### PR TITLE
Add test script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # ArtifactoftheEstablisher
+
+## Running Tests
+
+Install dependencies if you haven't already:
+
+```bash
+npm install
+```
+
+Then run the test suite with:
+
+```bash
+npm test
+```
  

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- add a `test` script that runs Jest
- document how to run the tests locally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc6154ec832393ab21b3c6cc1071