### PR TITLE
Improve project listing and edit dialog

### DIFF
--- a/components/projectdialog/EditProjectDialog.tsx
+++ b/components/projectdialog/EditProjectDialog.tsx
@@ -171,7 +171,11 @@ export default function EditProjectDialog({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Edit Project | {project.projectNumber} | {project.projectTitle}</DialogTitle>
+      <DialogTitle>
+        Edit Project | {project.projectNumber} |
+        {project.presenter ? `${project.presenter} - ` : ''}
+        {project.projectTitle}
+      </DialogTitle>
       <DialogContent dividers sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <TextField
           label="Project Number"

--- a/pages/dashboard/businesses/[fileId].tsx
+++ b/pages/dashboard/businesses/[fileId].tsx
@@ -263,7 +263,11 @@ export default function SingleFilePage({
                 <ListItem key={proj.projectNumber} sx={{ cursor: 'pointer' }} onClick={() => handleProjectClick(proj)}>
                   <ListItemText
                     primary={`${proj.projectNumber} — ${proj.presenter ? proj.presenter + ' - ' : ''}${proj.projectTitle}`}
-                    secondary={`HK$${Number(proj.amount).toLocaleString()} | ${proj.paid === 'TRUE' ? 'Paid' : 'Unpaid'}${proj.paid === 'TRUE' && proj.paidOnDate ? ` | ${proj.paidOnDate}` : ''}`}
+                    secondary={`HK$${Number(proj.amount).toLocaleString()} | ${
+                      proj.paid === 'TRUE' ? 'Paid' : 'Unpaid'
+                    }${
+                      proj.paid === 'TRUE' && proj.paidOnDate ? ` | ${proj.paidOnDate}` : ''
+                    } | ${proj.invoiceCompany}`}
                   />
                 </ListItem>
               ))}


### PR DESCRIPTION
## Summary
- show invoice company in project list
- add presenter info to Edit Project dialog title

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d0eb95488323b1c958e2ddfd9610