### PR TITLE
Use Firestore for subsidiary info

### DIFF
--- a/pages/dashboard/businesses/[fileId].tsx
+++ b/pages/dashboard/businesses/[fileId].tsx
@@ -5,7 +5,7 @@ import { getSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import React, { useState, useMemo, useEffect } from 'react';
 import SidebarLayout from '../../../components/SidebarLayout';
-import { findPMSReferenceLogFile, fetchReferenceNames, fetchAddressBook, fetchBankAccounts, fetchSubsidiaryData } from '../../../lib/pmsReference';
+import { findPMSReferenceLogFile, fetchReferenceNamesFS, fetchAddressBook, fetchBankAccounts, fetchSubsidiaryDataFS } from '../../../lib/pmsReference';
 import { initializeApis } from '../../../lib/googleApi';
 import { fetchProjectRows, listProjectOverviewFiles, ProjectRow } from '../../../lib/projectOverview';
 import { Box, Typography, Card, CardContent, List, ListItem, ListItemText, IconButton, Button, FormControl, InputLabel, Select, MenuItem, ToggleButton, ToggleButtonGroup } from '@mui/material';
@@ -305,8 +305,7 @@ export const getServerSideProps: GetServerSideProps<FileViewProps> = async (ctx)
   try {
     const { drive, sheets } = initializeApis('user', { accessToken: session.accessToken as string });
     const projectsByCategory = await listProjectOverviewFiles(drive);
-    const pmsRefLogId = await findPMSReferenceLogFile(drive);
-    const referenceMapping = await fetchReferenceNames(sheets, pmsRefLogId);
+    const referenceMapping = await fetchReferenceNamesFS();
 
     if (!fileId || fileId === 'select') {
       return {
@@ -366,7 +365,7 @@ export const getServerSideProps: GetServerSideProps<FileViewProps> = async (ctx)
     const addressBook = await fetchAddressBook(sheets, pmsRefLogId);
     const clients = addressBook.map((c) => ({ companyName: c.companyName }));
     const bankAccounts = await fetchBankAccounts(sheets, pmsRefLogId);
-    const allSubsidiaries = await fetchSubsidiaryData(sheets, pmsRefLogId);
+    const allSubsidiaries = await fetchSubsidiaryDataFS();
     const subsidiaryInfo = allSubsidiaries.find((r) => r.identifier === shortCode) || null;
 
     return {
@@ -387,8 +386,7 @@ export const getServerSideProps: GetServerSideProps<FileViewProps> = async (ctx)
     console.error('[getServerSideProps fileId] error:', err);
     const { drive } = initializeApis('user', { accessToken: session.accessToken as string });
     const projectsByCategory = await listProjectOverviewFiles(drive);
-    const pmsRefLogId = await findPMSReferenceLogFile(drive);
-    const referenceMapping = await fetchReferenceNames(sheets, pmsRefLogId);
+    const referenceMapping = await fetchReferenceNamesFS();
     return {
       props: {
         fileId: 'select',


### PR DESCRIPTION
## Summary
- pull subsidiary reference data from Firestore instead of Google Sheets
- adjust business dashboard page to use new Firestore helpers

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68444f1fd1a88323a14d31c8662ff391