### PR TITLE
Switch subsidiary data to Firestore

### DIFF
--- a/lib/firestoreSubsidiaries.ts
+++ b/lib/firestoreSubsidiaries.ts
@@ -1,0 +1,34 @@
+import { collection, getDocs } from 'firebase/firestore'
+import { db } from './firebase'
+
+export interface SubsidiaryData {
+  identifier: string
+  englishName: string
+  chineseName: string
+  email: string
+  phone: string
+  room: string
+  building: string
+  street: string
+  district: string
+  region: string
+}
+
+export async function fetchSubsidiaries(): Promise<SubsidiaryData[]> {
+  const snap = await getDocs(collection(db, 'Subsidiaries'))
+  return snap.docs.map(d => {
+    const data = d.data() as any
+    return {
+      identifier: d.id,
+      englishName: data.englishName || '',
+      chineseName: data.chineseName || '',
+      email: data.email || '',
+      phone: data.phone || '',
+      room: data.addressLine1 || '',
+      building: data.addressLine2 || '',
+      street: data.addressLine3 || '',
+      district: data.addressLine4 || '',
+      region: data.region || '',
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- add Firestore helper to load subsidiaries
- pull subsidiary data and reference names from Firestore in dashboard file view

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68448781f6a08323ba7b018d13560f0e