### PR TITLE
Fix secret manager fallback

### DIFF
--- a/lib/server/secretManager.ts
+++ b/lib/server/secretManager.ts
@@ -14,21 +14,23 @@ interface SecretFetchResult {
 }
 
 export async function loadSecrets(): Promise<SecretFetchResult> {
-  if (
-    !serviceAccountCredentials.project_id ||
-    !serviceAccountCredentials.client_email ||
-    !serviceAccountCredentials.private_key
-  ) {
-    throw new Error('Service account credentials are missing.');
-  }
+  const useExplicitCreds =
+    serviceAccountCredentials.project_id &&
+    serviceAccountCredentials.client_email &&
+    serviceAccountCredentials.private_key;
 
-  const client = new SecretManagerServiceClient({
-    credentials: {
-      client_email: serviceAccountCredentials.client_email,
-      private_key: serviceAccountCredentials.private_key,
-    },
-    projectId: serviceAccountCredentials.project_id,
-  });
+  const client = useExplicitCreds
+    ? new SecretManagerServiceClient({
+        credentials: {
+          client_email: serviceAccountCredentials.client_email,
+          private_key: serviceAccountCredentials.private_key,
+        },
+        projectId: serviceAccountCredentials.project_id,
+      })
+    : new SecretManagerServiceClient();
+
+  const projectId =
+    serviceAccountCredentials.project_id || (await client.getProjectId());
 
   const secrets: Record<string, string> = {};
   const diagnostics = {
@@ -48,7 +50,7 @@ export async function loadSecrets(): Promise<SecretFetchResult> {
   for (const { name, key } of secretNames) {
     try {
       const [version] = await client.accessSecretVersion({
-        name: `projects/${serviceAccountCredentials.project_id}/secrets/${name}/versions/latest`,
+        name: `projects/${projectId}/secrets/${name}/versions/latest`,
       });
 
       const data = version.payload?.data;


### PR DESCRIPTION
## Summary
- handle missing service account credentials by falling back to ADC in `loadSecrets`

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684df47618648323a442dd095e624d8f