### PR TITLE
Improve ADC fallback diagnostics

### DIFF
--- a/lib/server/secretManager.ts
+++ b/lib/server/secretManager.ts
@@ -20,6 +20,15 @@ export async function loadSecrets(): Promise<SecretFetchResult> {
     Boolean(serviceAccountCredentials.private_key);
 
   if (!hasExplicitCreds) {
+    const missing: string[] = [];
+    if (!serviceAccountCredentials.project_id) missing.push('GOOGLE_PROJECT_ID');
+    if (!serviceAccountCredentials.client_email)
+      missing.push('GOOGLE_CLIENT_EMAIL');
+    if (!serviceAccountCredentials.private_key)
+      missing.push('GOOGLE_PRIVATE_KEY');
+    console.warn(
+      `[secretManager] Missing credentials: ${missing.join(', ') || 'unknown'}`
+    );
     console.log(
       '[secretManager] Falling back to Application Default Credentials.'
     );


### PR DESCRIPTION
## Summary
- add log when falling back to Application Default Credentials in `loadSecrets`

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684df47618648323a442dd095e624d8f