### PR TITLE
Switch to env vars for secrets

### DIFF
--- a/functions/src/app/api/auth/[...nextauth]/handler.ts
+++ b/functions/src/app/api/auth/[...nextauth]/handler.ts
@@ -1,5 +1,5 @@
 // functions/src/app/api/auth/[...nextauth]/handler.ts
-import { loadSecrets, GOOGLE_PROJECT_ID, GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY } from '../../../loadSecrets';
+import { loadSecrets } from '../../../loadSecrets';
 
 export function handler(req: any, res: any) {
   const { clientEmail } = loadSecrets();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,19 +1,11 @@
 // functions/src/index.ts
 import * as functions from 'firebase-functions';
-import { defineSecret } from 'firebase-functions/params';
 import { initializeApis } from '../../lib/googleApi';
-import {
-  loadSecrets,
-  GOOGLE_PROJECT_ID,
-  GOOGLE_CLIENT_EMAIL,
-  GOOGLE_PRIVATE_KEY,
-} from '../../lib/server/loadSecrets';
+import { loadSecrets } from '../../lib/server/loadSecrets';
 import { findPMSReferenceLogFile, fetchAddressBook, fetchBankAccounts, fetchReferenceNames, fetchSubsidiaryData } from '../../lib/pmsReference';
 import { listProjectOverviewFiles, fetchProjectRows } from '../../lib/projectOverview';
 
-export const clients = functions
-  .runWith({ secrets: [GOOGLE_PROJECT_ID, GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY] })
-  .https.onRequest(async (req, res) => {
+export const clients = functions.https.onRequest(async (req, res) => {
   try {
     const creds = loadSecrets();
     const { drive, sheets } = initializeApis('service', {
@@ -33,9 +25,7 @@ export const clients = functions
   }
 });
 
-export const businesses = functions
-  .runWith({ secrets: [GOOGLE_PROJECT_ID, GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY] })
-  .https.onRequest(async (req, res) => {
+export const businesses = functions.https.onRequest(async (req, res) => {
   try {
     const creds = loadSecrets();
     const { drive, sheets } = initializeApis('service', {

--- a/lib/server/loadSecrets.ts
+++ b/lib/server/loadSecrets.ts
@@ -1,14 +1,12 @@
 // lib/server/loadSecrets.ts
-import { defineSecret } from 'firebase-functions/params';
-
-export const GOOGLE_PROJECT_ID = defineSecret('GOOGLE_PROJECT_ID');
-export const GOOGLE_CLIENT_EMAIL = defineSecret('GOOGLE_CLIENT_EMAIL');
-export const GOOGLE_PRIVATE_KEY = defineSecret('GOOGLE_PRIVATE_KEY');
+export const GOOGLE_PROJECT_ID = 'GOOGLE_PROJECT_ID';
+export const GOOGLE_CLIENT_EMAIL = 'GOOGLE_CLIENT_EMAIL';
+export const GOOGLE_PRIVATE_KEY = 'GOOGLE_PRIVATE_KEY';
 
 export function loadSecrets() {
   return {
-    projectId: GOOGLE_PROJECT_ID.value() || process.env.GOOGLE_PROJECT_ID,
-    clientEmail: GOOGLE_CLIENT_EMAIL.value() || process.env.GOOGLE_CLIENT_EMAIL,
-    privateKey: GOOGLE_PRIVATE_KEY.value() || process.env.GOOGLE_PRIVATE_KEY,
+    projectId: process.env.GOOGLE_PROJECT_ID,
+    clientEmail: process.env.GOOGLE_CLIENT_EMAIL,
+    privateKey: process.env.GOOGLE_PRIVATE_KEY,
   };
 }

--- a/lib/server/secretManager.ts
+++ b/lib/server/secretManager.ts
@@ -2,12 +2,7 @@
 
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import { TextDecoder } from 'util';
-import {
-  loadSecrets,
-  GOOGLE_PROJECT_ID,
-  GOOGLE_CLIENT_EMAIL,
-  GOOGLE_PRIVATE_KEY,
-} from './loadSecrets';
+import { loadSecrets } from './loadSecrets';
 
 interface SecretFetchResult {
   secrets: Record<string, string>;

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -3,15 +3,7 @@
 import NextAuth, { NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import { loadAppSecrets } from '../../../lib/server/secretManager';
-import {
-  onRequest,
-} from 'firebase-functions/v2/https';
-import {
-  loadSecrets,
-  GOOGLE_PROJECT_ID,
-  GOOGLE_CLIENT_EMAIL,
-  GOOGLE_PRIVATE_KEY,
-} from '../../../lib/server/loadSecrets';
+import { loadSecrets } from '../../../lib/server/loadSecrets';
 
 let dynamicAuthOptions: NextAuthOptions | null = null;
 
@@ -154,12 +146,3 @@ export default async function auth(req, res) {
   }
 }
 
-export const authHandler = onRequest(
-  {
-    secrets: [GOOGLE_PROJECT_ID, GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY],
-  },
-  async (req, res) => {
-    const { clientEmail } = loadSecrets();
-    res.status(200).send(`NextAuth ready with client: ${clientEmail}`);
-  }
-);


### PR DESCRIPTION
## Summary
- drop `defineSecret` usage
- load credentials directly from env vars

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588588281083239cfbe10356327bac