### PR TITLE
Fix missing API base URL

### DIFF
--- a/pages/dashboard/businesses/[fileId].tsx
+++ b/pages/dashboard/businesses/[fileId].tsx
@@ -61,11 +61,12 @@ export default function SingleFilePage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedProject, setSelectedProject] = useState<SingleProjectData | null>(null);
   const [data, setData] = useState<FileViewProps | null>(null);
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
   useEffect(() => {
     if (!router.isReady) return;
     const id = (router.query.fileId as string) || 'select';
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/businesses/${id}`)
+    fetch(`${API_BASE_URL}/businesses/${id}`)
       .then(res => (res.ok ? res.json() : null))
       .then(setData)
       .catch(() => {});

--- a/pages/dashboard/businesses/index.tsx
+++ b/pages/dashboard/businesses/index.tsx
@@ -14,9 +14,10 @@ interface BusinessFile {
 export default function BusinessesPage() {
   const router = useRouter();
   const [projectsByCategory, setProjectsByCategory] = useState<Record<string, BusinessFile[]>>({});
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/businesses`)
+    fetch(`${API_BASE_URL}/businesses`)
       .then(res => res.ok ? res.json() : { projectsByCategory: {} })
       .then(data => setProjectsByCategory(data.projectsByCategory || {}))
       .catch(() => {});

--- a/pages/dashboard/database.tsx
+++ b/pages/dashboard/database.tsx
@@ -53,9 +53,10 @@ export default function DatabasePage() {
   const [clients, setClients] = useState<AddressBookEntry[]>([]);
   const [bankAccounts, setBankAccounts] = useState<BankAccount[]>([]);
   const [error, setError] = useState<string | undefined>(undefined);
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/clients`)
+    fetch(`${API_BASE_URL}/clients`)
       .then(res => res.ok ? res.json() : Promise.reject())
       .then(data => {
         setClients(data.clients || []);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,8 +7,10 @@ import SidebarLayout from '../components/SidebarLayout';
 export default function MainPage() {
   const [firstName, setFirstName] = useState('');
 
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
+
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/session`)
+    fetch(`${API_BASE_URL}/auth/session`)
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (data?.user?.name) {


### PR DESCRIPTION
## Summary
- default to `/api` if `NEXT_PUBLIC_API_BASE_URL` is not defined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab2bce2c88323b3b7e23ee06d4070