### PR TITLE
Switch coaching sessions to Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ NEXT_PUBLIC_FIREBASE_APP_ID
 NEXT_PUBLIC_FIREBASE_DATABASE_ID
 ```
 
+### Firestore Security Rules
+
+When deploying the `mel-sessions` database, configure rules that allow the front end to read data while restricting writes to your service account:
+
+```firestore
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isServiceAccount() {
+      return request.auth.token.email.matches('.*@.*\\.gserviceaccount\\.com');
+    }
+
+    match /Students/{studentId}/{subDoc=**} {
+      allow read: if true;
+      allow write: if isServiceAccount();
+    }
+
+    match /Sessions/{sessionId}/{subDoc=**} {
+      allow read: if true;
+      allow write: if isServiceAccount();
+    }
+  }
+}
+```
+
+These rules mirror the environment used in development and should be adjusted if you introduce Firebase Auth or other access controls.
+
 Ensure these variables are available in your deployment environment so the
 application can retrieve additional secrets from Secret Manager.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ Required variables:
 - `GOOGLE_CLIENT_EMAIL`
 - `GOOGLE_PRIVATE_KEY`
 
+The frontend needs Firebase configuration variables. Set these as environment variables (for example in Vercel or `.env`):
+
+```
+NEXT_PUBLIC_FIREBASE_API_KEY
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+NEXT_PUBLIC_FIREBASE_PROJECT_ID
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+NEXT_PUBLIC_FIREBASE_APP_ID
+# Optional: specify a Firestore database other than `(default)`
+NEXT_PUBLIC_FIREBASE_DATABASE_ID
+```
+
 Ensure these variables are available in your deployment environment so the
 application can retrieve additional secrets from Secret Manager.
 

--- a/components/StudentDialog/Overview.tsx
+++ b/components/StudentDialog/Overview.tsx
@@ -16,7 +16,7 @@ export default function Overview({ abbr, serviceMode }: Props) {
 
   useEffect(() => {
     let mounted = true
-    getDoc(doc(db, 'students', abbr))
+    getDoc(doc(db, 'Students', abbr))
       .then(snap => {
         if (mounted && snap.exists()) {
           setData(snap.data())

--- a/components/StudentDialog/Overview.tsx
+++ b/components/StudentDialog/Overview.tsx
@@ -16,12 +16,15 @@ export default function Overview({ abbr, serviceMode }: Props) {
 
   useEffect(() => {
     let mounted = true
+    console.log('[Overview] fetching', abbr)
     getDoc(doc(db, 'Students', abbr))
       .then(snap => {
         if (mounted && snap.exists()) {
+          console.log('[Overview] data', snap.data())
           setData(snap.data())
         }
       })
+      .catch(err => console.error('[Overview] error', err))
       .finally(() => mounted && setLoading(false))
     return () => { mounted = false }
   }, [abbr])

--- a/components/StudentDialog/Sessions.tsx
+++ b/components/StudentDialog/Sessions.tsx
@@ -39,6 +39,7 @@ export default function Sessions({ abbr, serviceMode }: Props) {
   useEffect(() => {
     let mounted = true
     ;(async () => {
+      console.log('[Sessions] fetching sessions for', abbr)
       const stu = await getDoc(doc(db, 'Students', abbr))
       const account = stu.exists() ? (stu.data() as any).account : abbr
 
@@ -47,6 +48,7 @@ export default function Sessions({ abbr, serviceMode }: Props) {
         where('sessionName', '==', account)
       )
       const sessSnap = await getDocs(sessQ)
+      console.log('[Sessions] found', sessSnap.size, 'sessions')
 
       const rowsData = await Promise.all(
         sessSnap.docs.map(async d => {
@@ -83,6 +85,7 @@ export default function Sessions({ abbr, serviceMode }: Props) {
 
       if (!mounted) return
       setRows(rowsData.sort((a, b) => (b.date?.getTime() || 0) - (a.date?.getTime() || 0)))
+      console.log('[Sessions] rows loaded', rowsData.length)
     })()
       .catch(console.error)
       .finally(() => mounted && setLoading(false))

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,3 +5,6 @@ export const serviceAccountCredentials = {
   client_email: process.env.GOOGLE_CLIENT_EMAIL || '',
   private_key: (process.env.GOOGLE_PRIVATE_KEY || '').replace(/\\n/g, '\n'),
 };
+
+const serviceVars = ['GOOGLE_PROJECT_ID','GOOGLE_CLIENT_EMAIL','GOOGLE_PRIVATE_KEY'];
+export const serviceAccountReady = serviceVars.every(v => !!process.env[v]);

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -13,14 +13,15 @@ const firebaseConfig = {
 }
 
 if (process.env.NODE_ENV === 'development') {
-  console.log('🔥 Firebase config:', firebaseConfig)
+  console.log('🔥 Firebase config:', firebaseConfig, 'DB:', process.env.NEXT_PUBLIC_FIREBASE_DATABASE_ID || '(default)')
 }
 
-const app = !getApps().length
-  ? initializeApp(firebaseConfig)
-  : getApp()
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp()
 
-export const db = getFirestore(app)
+const databaseId = process.env.NEXT_PUBLIC_FIREBASE_DATABASE_ID
+export const db = databaseId
+  ? getFirestore(app, databaseId)
+  : getFirestore(app)
 // after you create/export `db`...
 if (typeof window !== 'undefined') {
   // @ts-ignore

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,29 +1,45 @@
 // lib/firebase.ts
-
 import { initializeApp, getApps, getApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
 
-const firebaseConfig = {
-  apiKey:               process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-  authDomain:           process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-  projectId:            process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-  storageBucket:        process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
-  messagingSenderId:    process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-  appId:                process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
+const required = [
+  'NEXT_PUBLIC_FIREBASE_API_KEY',
+  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+  'NEXT_PUBLIC_FIREBASE_APP_ID',
+]
+
+const missing = required.filter(v => !process.env[v])
+export const firebaseReady = missing.length === 0
+
+let db: ReturnType<typeof getFirestore> | null = null
+
+if (firebaseReady) {
+  const firebaseConfig = {
+    apiKey:            process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+    authDomain:        process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+    projectId:         process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+    storageBucket:     process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+    appId:             process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log('🔥 Firebase config:', firebaseConfig, 'DB:', process.env.NEXT_PUBLIC_FIREBASE_DATABASE_ID || '(default)')
+  }
+
+  const app = !getApps().length ? initializeApp(firebaseConfig) : getApp()
+  const databaseId = process.env.NEXT_PUBLIC_FIREBASE_DATABASE_ID
+  db = databaseId ? getFirestore(app, databaseId) : getFirestore(app)
+
+  if (typeof window !== 'undefined') {
+    // @ts-ignore
+    window.db = db
+  }
+} else if (typeof window !== 'undefined') {
+  console.error('Missing Firebase env vars:', missing.join(', '))
 }
 
-if (process.env.NODE_ENV === 'development') {
-  console.log('🔥 Firebase config:', firebaseConfig, 'DB:', process.env.NEXT_PUBLIC_FIREBASE_DATABASE_ID || '(default)')
-}
-
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp()
-
-const databaseId = process.env.NEXT_PUBLIC_FIREBASE_DATABASE_ID
-export const db = databaseId
-  ? getFirestore(app, databaseId)
-  : getFirestore(app)
-// after you create/export `db`...
-if (typeof window !== 'undefined') {
-  // @ts-ignore
-  window.db = db
-}
+export { db }

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,5 +13,5 @@ module.exports = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  output: 'export',
+  // Remove static export so API routes (like NextAuth) work on Vercel
 };

--- a/pages/api/status.ts
+++ b/pages/api/status.ts
@@ -1,0 +1,10 @@
+// pages/api/status.ts
+import { NextApiRequest, NextApiResponse } from 'next'
+import { firebaseReady } from '../../lib/firebase'
+
+const serviceVars = ['GOOGLE_PROJECT_ID','GOOGLE_CLIENT_EMAIL','GOOGLE_PRIVATE_KEY']
+const serviceAccountReady = serviceVars.every(v => !!process.env[v])
+
+export default function handler(_req:NextApiRequest,res:NextApiResponse) {
+  res.status(200).json({ firebaseReady, serviceAccountReady })
+}

--- a/pages/dashboard/businesses/coachingsessions.tsx
+++ b/pages/dashboard/businesses/coachingsessions.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from 'react'
 import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
 import SidebarLayout from '../../../components/SidebarLayout'
-import { db } from '../../../lib/firebase'
+import { db, firebaseReady } from '../../../lib/firebase'
 import {
    Typography,
    Grid,
@@ -49,6 +49,12 @@ export default function CoachingSessions() {
 
   useEffect(() => {
     let mounted = true
+
+    if (!firebaseReady) {
+      console.error('Firebase not initialized')
+      setLoading(false)
+      return
+    }
 
     async function loadAll() {
       console.log('[CoachingSessions] Fetching Students collection')
@@ -138,6 +144,11 @@ export default function CoachingSessions() {
 
   return (
     <SidebarLayout>
+      {!firebaseReady && (
+        <Box p={3} color="error.main">
+          <Typography variant="h6">Configuration error: Firebase not available.</Typography>
+        </Box>
+      )}
       {/* header */}
       <Box sx={{ p:3, display:'flex', alignItems:'center', gap:2 }}>
         <Typography variant="h4" sx={{ flexGrow:1 }}>

--- a/pages/dashboard/businesses/coachingsessions.tsx
+++ b/pages/dashboard/businesses/coachingsessions.tsx
@@ -51,11 +51,13 @@ export default function CoachingSessions() {
     let mounted = true
 
     async function loadAll() {
+      console.log('[CoachingSessions] Fetching Students collection')
       const snap = await getDocs(collection(db, 'Students'))
       const basics = snap.docs.map(d => ({
         abbr:    d.id,
         account: (d.data() as any).account,
       }))
+      console.log('[CoachingSessions] Found', basics.length, 'students')
 
       if (!mounted) return
       setStudents(basics.map(b => ({
@@ -115,6 +117,12 @@ export default function CoachingSessions() {
                 : s
             )
           )
+          console.log(`[CoachingSessions] Updated ${b.abbr}`, {
+            sex,
+            balanceDue,
+            total,
+            upcoming,
+          })
         })().catch(console.error)
       })
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,27 +3,39 @@
 import { Box, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import SidebarLayout from '../components/SidebarLayout';
-import { firebaseReady } from '../lib/firebase';
+
+interface Status { firebaseReady: boolean; serviceAccountReady: boolean }
 
 export default function MainPage() {
   const [firstName, setFirstName] = useState('');
+  const [status, setStatus] = useState<Status | null>(null);
+  const [authenticated, setAuthenticated] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!firebaseReady) return;
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/session`)
+    fetch('/api/status')
+      .then(r => r.ok ? r.json() : null)
+      .then(setStatus)
+      .catch(() => setStatus({ firebaseReady: false, serviceAccountReady: false }));
+
+    fetch('/api/auth/session')
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (data?.user?.name) {
           setFirstName(data.user.name.split(' ')[0]);
+          setAuthenticated(true);
+        } else {
+          setAuthenticated(false);
         }
       })
-      .catch(() => {});
+      .catch(() => setAuthenticated(false));
   }, []);
 
   return (
     <SidebarLayout>
       <Box sx={{ p: 3 }}>
-        {firebaseReady ? (
+        {!status || authenticated === null ? (
+          <Typography>Loading…</Typography>
+        ) : status.firebaseReady && status.serviceAccountReady && authenticated ? (
           <>
             <Typography variant="h4" gutterBottom>
               Welcome{firstName ? `, ${firstName}` : ''}
@@ -34,7 +46,9 @@ export default function MainPage() {
           </>
         ) : (
           <Typography variant="h6" color="error">
-            Configuration error: Firebase not available.
+            { !status.firebaseReady || !status.serviceAccountReady
+              ? 'Configuration error: backend not available.'
+              : 'You must be signed in to use this service.' }
           </Typography>
         )}
       </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,11 +3,13 @@
 import { Box, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import SidebarLayout from '../components/SidebarLayout';
+import { firebaseReady } from '../lib/firebase';
 
 export default function MainPage() {
   const [firstName, setFirstName] = useState('');
 
   useEffect(() => {
+    if (!firebaseReady) return;
     fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/session`)
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
@@ -21,10 +23,20 @@ export default function MainPage() {
   return (
     <SidebarLayout>
       <Box sx={{ p: 3 }}>
-        <Typography variant="h4" gutterBottom>
-          Welcome{firstName ? `, ${firstName}` : ''}
-        </Typography>
-        <Typography variant="body1">Please select an option from the sidebar.</Typography>
+        {firebaseReady ? (
+          <>
+            <Typography variant="h4" gutterBottom>
+              Welcome{firstName ? `, ${firstName}` : ''}
+            </Typography>
+            <Typography variant="body1">
+              Please select an option from the sidebar.
+            </Typography>
+          </>
+        ) : (
+          <Typography variant="h6" color="error">
+            Configuration error: Firebase not available.
+          </Typography>
+        )}
       </Box>
     </SidebarLayout>
   );


### PR DESCRIPTION
## Summary
- fix path typo in student Overview page
- refactor sessions list to pull from top-level `Sessions` collection
- compute totals and upcoming sessions using appointment history
- add ability to specify Firestore database via env var

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880e6ad713c83239ef1de7a4ca0b8d7