### PR TITLE
Improve student dialog and Firestore docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ArtifactoftheEstablisher
+
+## Firestore Structure
+
+Each student document lives under the `Students` collection. Certain pieces of
+information are recorded as time stamped history in subcollections. When a value
+is edited a new document is added to the appropriate subcollection with a
+`timestamp` field so the history can be audited.
+
+Required subcollections and fields:
+
+- `legalName` – documents contain `firstName`, `lastName` and `timestamp`.
+- `sex` – documents contain `sex` and `timestamp`.
+- `birthDate` – documents contain `birthDate` and `timestamp`.
+- `billingType` – documents contain `billingType` and `timestamp`.
+
+All subcollection document IDs can be auto generated.
  

--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -2,12 +2,13 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import { TextField, MenuItem, Typography } from '@mui/material'
-import { doc, updateDoc, collection, getDocs, orderBy } from 'firebase/firestore'
+import { addDoc, collection, getDocs } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 
 export interface InlineEditProps {
   value: any
-  fieldPath: string       // e.g. "Students/KT/firstName"
+  fieldPath: string       // e.g. "Students/KT/sex"
+  fieldKey?: string       // field name stored in the subcollection document
   editable: boolean
   serviceMode?: boolean
   type: 'text' | 'number' | 'date' | 'select'
@@ -17,12 +18,13 @@ export interface InlineEditProps {
 export default function InlineEdit({
   value,
   fieldPath,
+  fieldKey = 'value',
   editable,
   serviceMode = false,
   type,
   options,
 }: InlineEditProps) {
-  const [editing, setEditing] = useState(false)
+  const [editing, setEditing] = useState(value === undefined || value === '')
   const [draft, setDraft] = useState(value)
   const ref = useRef<HTMLInputElement>(null)
 
@@ -31,12 +33,19 @@ export default function InlineEdit({
     if (editing && ref.current) ref.current.focus()
   }, [editing])
 
+  useEffect(() => {
+    setDraft(value)
+    if (value === undefined || value === '') {
+      setEditing(true)
+    }
+  }, [value])
+
   const save = async (v: any) => {
-    const [col, docId, field] = fieldPath.split('/')
+    const [col, docId, collectionName] = fieldPath.split('/')
     try {
-      console.log(`💾 update ${col}/${docId} ${field}=${v}`)
-      await updateDoc(doc(db, col, docId), {
-        [field]: v,
+      console.log(`💾 add ${col}/${docId}/${collectionName} ${fieldKey}=${v}`)
+      await addDoc(collection(db, col, docId, collectionName), {
+        [fieldKey]: v,
         timestamp: new Date(),
       })
       setDraft(v)

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -30,24 +30,31 @@ export default function BillingTab({
     <Box>
       {Object.entries(billing)
         .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => (
-          <Box key={k} mb={2}>
-            <Typography variant="subtitle1">{LABELS[k]}</Typography>
-            {k === 'baseRate' ? (
-              <Typography>{
-                v != null ? formatCurrency(Number(v)) : '-'
-              }</Typography>
-            ) : (
-              <InlineEdit
-                value={v != null ? v : '-'}
-                fieldPath={`Students/${billing.abbr}/${k}`}
-                editable={!['balanceDue', 'voucherBalance'].includes(k)}
-                serviceMode={serviceMode}
-                type={k.includes('Date') ? 'date' : 'text'}
-              />
-            )}
-          </Box>
-        ))}
+        .map(([k, v]) => {
+          const path =
+            k === 'defaultBillingType'
+              ? `Students/${billing.abbr}/billingType`
+              : `Students/${billing.abbr}/${k}`
+          return (
+            <Box key={k} mb={2}>
+              <Typography variant="subtitle1">{LABELS[k]}</Typography>
+              {k === 'baseRate' ? (
+                <Typography>{
+                  v != null ? formatCurrency(Number(v)) : '-'
+                }</Typography>
+              ) : (
+                <InlineEdit
+                  value={v}
+                  fieldPath={path}
+                  fieldKey={k}
+                  editable={!['balanceDue', 'voucherBalance'].includes(k)}
+                  serviceMode={serviceMode}
+                  type={k.includes('Date') ? 'date' : 'text'}
+                />
+              )}
+            </Box>
+          )
+        })}
     </Box>
   )
 }

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -29,6 +29,7 @@ import SessionsTab from './SessionsTab'
 
 export interface OverviewTabProps {
   abbr: string
+  account: string
   open: boolean
   onClose: () => void
   serviceMode: boolean
@@ -36,6 +37,7 @@ export interface OverviewTabProps {
 
 export default function OverviewTab({
   abbr,
+  account,
   open,
   onClose,
   serviceMode,
@@ -81,6 +83,14 @@ export default function OverviewTab({
       if (col === 'baseRate') {
         collectionName = 'BaseRateHistory'
         field = 'rate'
+      }
+      if (col === 'firstName' || col === 'lastName') {
+        collectionName = 'legalName'
+        field = col
+      }
+      if (col === 'defaultBillingType') {
+        collectionName = 'billingType'
+        field = 'billingType'
       }
       const snap = await getDocs(
         query(
@@ -207,13 +217,7 @@ export default function OverviewTab({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle sx={{ textAlign: 'left' }}>
-        {personal.firstName || personal.lastName ? (
-          `${personal.firstName} ${personal.lastName}`
-        ) : (
-          <CircularProgress size={16} />
-        )}
-      </DialogTitle>
+      <DialogTitle sx={{ textAlign: 'left' }}>{account}</DialogTitle>
       <DialogContent sx={{ display: 'flex', height: '70vh' }}>
         {loading ? (
           <Box
@@ -260,8 +264,9 @@ export default function OverviewTab({
                     <Typography>Loading…</Typography>
                   ) : (
                     <InlineEdit
-                      value={personal.sex || '-'}
+                      value={personal.sex}
                       fieldPath={`Students/${abbr}/sex`}
+                      fieldKey="sex"
                       editable={serviceMode}
                       type="select"
                       options={['Male', 'Female', 'Other']}

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -22,19 +22,26 @@ export default function PersonalTab({
     <Box>
       {Object.entries(personal)
         .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => (
-          <Box key={k} mb={2}>
-            <Typography variant="subtitle1">{LABELS[k]}</Typography>
-            <InlineEdit
-              value={v || '-'}
-              fieldPath={`Students/${personal.abbr}/${k}`}
-              editable // always editable
-              serviceMode={serviceMode}
-              type={k === 'sex' ? 'select' : k === 'birthDate' ? 'date' : 'text'}
-              options={k === 'sex' ? ['Male', 'Female', 'Other'] : undefined}
-            />
-          </Box>
-        ))}
+        .map(([k, v]) => {
+          const path =
+            k === 'firstName' || k === 'lastName'
+              ? `Students/${personal.abbr}/legalName`
+              : `Students/${personal.abbr}/${k}`
+          return (
+            <Box key={k} mb={2}>
+              <Typography variant="subtitle1">{LABELS[k]}</Typography>
+              <InlineEdit
+                value={v}
+                fieldPath={path}
+                fieldKey={k}
+                editable // always editable
+                serviceMode={serviceMode}
+                type={k === 'sex' ? 'select' : k === 'birthDate' ? 'date' : 'text'}
+                options={k === 'sex' ? ['Male', 'Female', 'Other'] : undefined}
+              />
+            </Box>
+          )
+        })}
     </Box>
   )
 }

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -35,7 +35,7 @@ interface StudentDetails extends StudentMeta {
 export default function CoachingSessions() {
   const [students, setStudents] = useState<StudentDetails[]>([])
   const [loading, setLoading] = useState(true)
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selected, setSelected] = useState<StudentDetails | null>(null)
   const [serviceMode, setServiceMode] = useState(false)
 
   useEffect(() => {
@@ -56,7 +56,7 @@ export default function CoachingSessions() {
 
       // 2) then in parallel load each student’s details
       basics.forEach((b) => {
-        ;(async () => {
+        (async () => {
           // a) latest sex & balanceDue
           const latest = async (col: string) => {
             console.log(`📥 ${b.abbr}/${col}`)
@@ -83,7 +83,7 @@ export default function CoachingSessions() {
             query(collection(db, 'Sessions'), where('sessionName', '==', b.account))
           )
           console.log(`   found ${sessSnap.size} sessions`)
-          let total = sessSnap.size
+          const total = sessSnap.size
           let upcoming = 0
           const now = new Date()
 
@@ -166,7 +166,7 @@ export default function CoachingSessions() {
         {students.map((s) => (
           <Grid item key={s.abbr} xs={12} sm={6} md={4}>
             <Card>
-              <CardActionArea onClick={() => setSelected(s.abbr)}>
+              <CardActionArea onClick={() => setSelected(s)}>
                 <CardContent>
                   <Typography variant="h6">{s.account}</Typography>
                   <Typography>
@@ -199,7 +199,8 @@ export default function CoachingSessions() {
 
       {selected && (
         <OverviewTab
-          abbr={selected}
+          abbr={selected.abbr}
+          account={selected.account}
           open
           onClose={() => setSelected(null)}
           serviceMode={serviceMode}


### PR DESCRIPTION
## Summary
- save inline edits as new docs in subcollections with a timestamp
- start edits when field values are missing
- use `legalName` and `billingType` collections for student info
- show account name as the dialog title in coaching sessions
- document Firestore structure

## Testing
- `npm run lint` *(fails: React must be in scope)*

------
https://chatgpt.com/codex/tasks/task_e_6885cec051dc8323990d85902adce3e6