### PR TITLE
Update gender label

### DIFF
--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -253,7 +253,7 @@ export default function OverviewTab({
                   </Typography>
 
                   <Typography variant="subtitle1">
-                    Sex{' '}
+                    Gender{' '}
                     {personalLoading.sex && <CircularProgress size={14} />}
                   </Typography>
                   {personalLoading.sex ? (

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -7,7 +7,7 @@ import InlineEdit from '../../common/InlineEdit'
 const LABELS: Record<string, string> = {
   firstName: 'First Name',
   lastName: 'Last Name',
-  sex: 'Sex',
+  sex: 'Gender',
   birthDate: 'Birth Date',
 }
 

--- a/lib/clientLogger.ts
+++ b/lib/clientLogger.ts
@@ -18,7 +18,9 @@ export function setupClientLogging() {
             userAgent: navigator.userAgent,
           }),
         }).catch(() => {});
-      } catch (_) {}
+      } catch (_) {
+        // ignore errors during client logging
+      }
       original(...args);
     };
   });


### PR DESCRIPTION
## Summary
- rename 'Sex' label to 'Gender' in OverviewTab
- update PersonalTab label map to use 'Gender'
- fix lint error by adding comment in client logger

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887d4c5f9408323a7ed3e1c563b0f52