### PR TITLE
Rename Total labels

### DIFF
--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -23,13 +23,19 @@ export default function BillingTab({
   abbr,
   billing,
   serviceMode,
+  totalSessions,
 }: {
   abbr: string
   billing: any
   serviceMode: boolean
+  totalSessions: number
 }) {
   return (
     <Box>
+      <Box mb={2}>
+        <Typography variant="subtitle2">Total Sessions</Typography>
+        <Typography variant="h6">{totalSessions}</Typography>
+      </Box>
       {Object.entries(billing)
         .filter(([k]) => k !== 'abbr')
         .map(([k, v]) => {

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -329,7 +329,12 @@ export default function OverviewTab({
                 />
               )}
               {tab === 2 && (
-                <BillingTab abbr={abbr} billing={billing} serviceMode={serviceMode} />
+                <BillingTab
+                  abbr={abbr}
+                  billing={billing}
+                  serviceMode={serviceMode}
+                  totalSessions={overview.total}
+                />
               )}
               {tab === 3 && (
                 sessionsLoading ? (

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -164,7 +164,7 @@ export default function OverviewTab({
       const sorted = dates.sort((a, b) => a.getTime() - b.getTime())
       const now = new Date()
       setOverview({
-        total: sorted.length,
+        totalSessions: sorted.length,
         upcoming: sorted.filter((d) => d > now).length,
         joint: sorted[0]?.toLocaleDateString() || '',
       })
@@ -287,7 +287,7 @@ export default function OverviewTab({
                     <Typography variant="h6">Loading…</Typography>
                   ) : (
                     <Typography variant="h6">
-                      {overview.total}
+                      {overview.totalSessions}
                       {overview.upcoming > 0
                         ? ` → ${overview.upcoming}`
                         : ''}
@@ -333,7 +333,7 @@ export default function OverviewTab({
                   abbr={abbr}
                   billing={billing}
                   serviceMode={serviceMode}
-                  totalSessions={overview.total}
+                  totalSessions={overview.totalSessions}
                 />
               )}
               {tab === 3 && (

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -165,7 +165,7 @@ export default function CoachingSessions() {
                     {s.sex ?? '–'} • Due: ${(s.balanceDue ?? 0).toFixed(2)}
                   </Typography>
                   <Typography>
-                    Total: {s.total}
+                    Total Sessions: {s.total}
                     {s.upcoming > 0 ? ` → ${s.upcoming}` : ''}
                   </Typography>
                 </CardContent>

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -30,7 +30,7 @@ interface StudentMeta {
 interface StudentDetails extends StudentMeta {
   sex?: string
   balanceDue?: number
-  total: number
+  totalSessions: number
   upcoming: number
 }
 
@@ -53,7 +53,7 @@ export default function CoachingSessions() {
       }))
 
       if (!mounted) return
-      setStudents(basics.map((b) => ({ ...b, total: 0, upcoming: 0 })))
+      setStudents(basics.map((b) => ({ ...b, totalSessions: 0, upcoming: 0 })))
       setLoading(false)
 
       // 2) then in parallel load each student’s details
@@ -129,7 +129,7 @@ export default function CoachingSessions() {
           setStudents((prev) =>
             prev.map((s) =>
               s.abbr === b.abbr
-                ? { ...s, sex, balanceDue, total, upcoming }
+                ? { ...s, sex, balanceDue, totalSessions: total, upcoming }
                 : s
             )
           )
@@ -165,7 +165,7 @@ export default function CoachingSessions() {
                     {s.sex ?? '–'} • Due: ${(s.balanceDue ?? 0).toFixed(2)}
                   </Typography>
                   <Typography>
-                    Total Sessions: {s.total}
+                    Total Sessions: {s.totalSessions}
                     {s.upcoming > 0 ? ` → ${s.upcoming}` : ''}
                   </Typography>
                 </CardContent>


### PR DESCRIPTION
## Summary
- update coaching session card label to "Total Sessions"
- show total session count in BillingTab
- forward count from OverviewTab to BillingTab

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688888fa97308323be75236e57a1b245