### PR TITLE
Refactor billing tab order

### DIFF
--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -19,7 +19,9 @@ const FIELD_KEYS = [
   'voucherBalance',
 ] as const
 
-const LABELS: Record<string, string> = {
+type FieldKey = (typeof FIELD_KEYS)[number]
+
+const LABELS: Record<FieldKey, string> = {
   baseRate: 'Base Rate',
   retainerStatus: 'Retainer Status',
   lastPaymentDate: 'Last Payment',

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -9,12 +9,22 @@ const formatCurrency = (n: number) =>
   )
 import InlineEdit from '../../common/InlineEdit'
 
+const FIELD_KEYS = [
+  'baseRate',
+  'retainerStatus',
+  'lastPaymentDate',
+  'defaultBillingType',
+  'billingCompany',
+  'balanceDue',
+  'voucherBalance',
+] as const
+
 const LABELS: Record<string, string> = {
-  billingCompany: 'Billing Company',
-  defaultBillingType: 'Default Billing Type',
   baseRate: 'Base Rate',
   retainerStatus: 'Retainer Status',
-  lastPaymentDate: 'Last Payment Date',
+  lastPaymentDate: 'Last Payment',
+  defaultBillingType: 'Default Billing Type',
+  billingCompany: 'Billing Company Info',
   balanceDue: 'Balance Due',
   voucherBalance: 'Voucher Balance',
 }
@@ -30,33 +40,30 @@ export default function BillingTab({
 }) {
   return (
     <Box>
-      {Object.entries(billing)
-        .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => {
-          const path =
-            k === 'defaultBillingType'
-              ? `Students/${abbr}/billingType`
-              : `Students/${abbr}/${k}`
-          return (
-            <Box key={k} mb={2}>
-              <Typography variant="subtitle1">{LABELS[k]}</Typography>
-              {k === 'baseRate' ? (
-                <Typography>{
-                  v != null ? formatCurrency(Number(v)) : '-'
-                }</Typography>
-              ) : (
-                <InlineEdit
-                  value={v}
-                  fieldPath={path}
-                  fieldKey={k}
-                  editable={!['balanceDue', 'voucherBalance'].includes(k)}
-                  serviceMode={serviceMode}
-                  type={k.includes('Date') ? 'date' : 'text'}
-                />
-              )}
-            </Box>
-          )
-        })}
+      {FIELD_KEYS.map((k) => {
+        const v = billing[k]
+        const path =
+          k === 'defaultBillingType'
+            ? `Students/${abbr}/billingType`
+            : `Students/${abbr}/${k}`
+        return (
+          <Box key={k} mb={2}>
+            <Typography variant="subtitle1">{LABELS[k]}</Typography>
+            {k === 'baseRate' ? (
+              <Typography>{v != null ? formatCurrency(Number(v)) : '-'}</Typography>
+            ) : (
+              <InlineEdit
+                value={v}
+                fieldPath={path}
+                fieldKey={k}
+                editable={!['balanceDue', 'voucherBalance'].includes(k)}
+                serviceMode={serviceMode}
+                type={k.includes('Date') ? 'date' : 'text'}
+              />
+            )}
+          </Box>
+        )
+      })}
     </Box>
   )
 }

--- a/lib/clientLogger.ts
+++ b/lib/clientLogger.ts
@@ -17,8 +17,12 @@ export function setupClientLogging() {
             pathname: window.location.pathname,
             userAgent: navigator.userAgent,
           }),
-        }).catch(() => {});
-      } catch (_) {}
+        }).catch(() => {
+          /* empty */
+        });
+      } catch (_) {
+        /* empty */
+      }
       original(...args);
     };
   });


### PR DESCRIPTION
## Summary
- define array of billing fields
- update labels
- render using ordered field array
- avoid empty block warnings in `clientLogger`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887d47a873c8323b398f0a6a3eaea14