### PR TITLE
Improve student session tabs

### DIFF
--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -10,11 +10,11 @@ const formatCurrency = (n: number) =>
 import InlineEdit from '../../common/InlineEdit'
 
 const LABELS: Record<string, string> = {
-  billingCompany: 'Billing Company',
+  billingCompany: 'Billing Company Info',
   defaultBillingType: 'Default Billing Type',
   baseRate: 'Base Rate',
   retainerStatus: 'Retainer Status',
-  lastPaymentDate: 'Last Payment Date',
+  lastPaymentDate: 'Last Payment',
   balanceDue: 'Balance Due',
   voucherBalance: 'Voucher Balance',
 }
@@ -28,35 +28,43 @@ export default function BillingTab({
   billing: any
   serviceMode: boolean
 }) {
+  const renderField = (k: string) => {
+    const v = billing[k]
+    const path =
+      k === 'defaultBillingType'
+        ? `Students/${abbr}/billingType`
+        : `Students/${abbr}/${k}`
+    return (
+      <Box key={k} mb={2}>
+        <Typography variant="subtitle2">{LABELS[k]}</Typography>
+        {k === 'baseRate' ? (
+          <Typography variant="h6">
+            {v != null ? formatCurrency(Number(v)) : '-'}
+          </Typography>
+        ) : (
+          <InlineEdit
+            value={v}
+            fieldPath={path}
+            fieldKey={k}
+            editable={!['balanceDue', 'voucherBalance'].includes(k)}
+            serviceMode={serviceMode}
+            type={k.includes('Date') ? 'date' : 'text'}
+          />
+        )}
+      </Box>
+    )
+  }
+
   return (
     <Box>
-      {Object.entries(billing)
-        .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => {
-          const path =
-            k === 'defaultBillingType'
-              ? `Students/${abbr}/billingType`
-              : `Students/${abbr}/${k}`
-          return (
-            <Box key={k} mb={2}>
-              <Typography variant="subtitle2">{LABELS[k]}</Typography>
-              {k === 'baseRate' ? (
-                <Typography variant="h6">{
-                  v != null ? formatCurrency(Number(v)) : '-'
-                }</Typography>
-              ) : (
-                <InlineEdit
-                  value={v}
-                  fieldPath={path}
-                  fieldKey={k}
-                  editable={!['balanceDue', 'voucherBalance'].includes(k)}
-                  serviceMode={serviceMode}
-                  type={k.includes('Date') ? 'date' : 'text'}
-                />
-              )}
-            </Box>
-          )
-        })}
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Billing Information
+      </Typography>
+      {['balanceDue', 'baseRate', 'retainerStatus', 'lastPaymentDate', 'voucherBalance'].map(renderField)}
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
+        Payment Information
+      </Typography>
+      {['defaultBillingType', 'billingCompany'].map(renderField)}
     </Box>
   )
 }

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -167,6 +167,7 @@ export default function OverviewTab({
         total: sorted.length,
         upcoming: sorted.filter((d) => d > now).length,
         joint: sorted[0]?.toLocaleDateString() || '',
+        last: sorted[sorted.length - 1]?.toLocaleDateString() || '',
       })
       setOverviewLoading(false)
 
@@ -253,7 +254,7 @@ export default function OverviewTab({
                   </Typography>
 
                   <Typography variant="subtitle2">
-                    Sex{' '}
+                    Gender{' '}
                     {personalLoading.sex && <CircularProgress size={14} />}
                   </Typography>
                   {personalLoading.sex ? (
@@ -325,6 +326,8 @@ export default function OverviewTab({
                 <PersonalTab
                   abbr={abbr}
                   personal={personal}
+                  jointDate={overview.joint}
+                  totalSessions={overview.total}
                   serviceMode={serviceMode}
                 />
               )}
@@ -332,7 +335,11 @@ export default function OverviewTab({
                 sessionsLoading ? (
                   <CircularProgress />
                 ) : (
-                  <SessionsTab sessions={sessions} />
+                  <SessionsTab
+                    sessions={sessions}
+                    lastSession={overview.last}
+                    totalSessions={overview.total}
+                  />
                 )
               )}
               {tab === 3 && (

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -7,17 +7,21 @@ import InlineEdit from '../../common/InlineEdit'
 const LABELS: Record<string, string> = {
   firstName: 'First Name',
   lastName: 'Last Name',
-  sex: 'Sex',
+  sex: 'Gender',
   birthDate: 'Birth Date',
 }
 
 export default function PersonalTab({
   abbr,
   personal,
+  jointDate,
+  totalSessions,
   serviceMode,
 }: {
   abbr: string
   personal: any
+  jointDate?: string
+  totalSessions?: number
   serviceMode: boolean
 }) {
   return (
@@ -41,6 +45,18 @@ export default function PersonalTab({
             </Box>
           )
         })}
+      {jointDate && (
+        <Box mb={2}>
+          <Typography variant="subtitle2">Joint Date</Typography>
+          <Typography variant="h6">{jointDate}</Typography>
+        </Box>
+      )}
+      {totalSessions != null && (
+        <Box mb={2}>
+          <Typography variant="subtitle2">Total Sessions</Typography>
+          <Typography variant="h6">{totalSessions}</Typography>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -7,6 +7,8 @@ const formatCurrency = (n: number) =>
     n,
   )
 import {
+  Box,
+  Typography,
   Table,
   TableHead,
   TableRow,
@@ -14,9 +16,34 @@ import {
   TableBody,
 } from '@mui/material'
 
-export default function SessionsTab({ sessions }: { sessions: any[] }) {
+export default function SessionsTab({
+  sessions,
+  lastSession,
+  totalSessions,
+}: {
+  sessions: any[]
+  lastSession?: string
+  totalSessions?: number
+}) {
   return (
-    <Table size="small">
+    <>
+      {(lastSession || totalSessions != null) && (
+        <Box mb={2}>
+          {lastSession && (
+            <>
+              <Typography variant="subtitle2">Last Session:</Typography>
+              <Typography variant="h6">{lastSession}</Typography>
+            </>
+          )}
+          {totalSessions != null && (
+            <>
+              <Typography variant="subtitle2">Total Sessions:</Typography>
+              <Typography variant="h6">{totalSessions}</Typography>
+            </>
+          )}
+        </Box>
+      )}
+      <Table size="small">
       <TableHead>
         <TableRow>
           {[
@@ -50,5 +77,6 @@ export default function SessionsTab({ sessions }: { sessions: any[] }) {
         ))}
       </TableBody>
     </Table>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- switch text from Sex to Gender
- show joint date and total session count in the Personal tab
- compute last session date for sessions tab
- reorganize Billing tab fields with headers
- display last session and total sessions above the session table

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a0c11d4988323b79aaed2d1077327