### PR TITLE
Improve student session tabs

### DIFF
--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -10,11 +10,11 @@ const formatCurrency = (n: number) =>
 import InlineEdit from '../../common/InlineEdit'
 
 const LABELS: Record<string, string> = {
-  billingCompany: 'Billing Company',
+  billingCompany: 'Billing Company Info',
   defaultBillingType: 'Default Billing Type',
   baseRate: 'Base Rate',
   retainerStatus: 'Retainer Status',
-  lastPaymentDate: 'Last Payment Date',
+  lastPaymentDate: 'Last Payment',
   balanceDue: 'Balance Due',
   voucherBalance: 'Voucher Balance',
 }
@@ -28,35 +28,43 @@ export default function BillingTab({
   billing: any
   serviceMode: boolean
 }) {
+  const renderField = (k: string) => {
+    const v = billing[k]
+    const path =
+      k === 'defaultBillingType'
+        ? `Students/${abbr}/billingType`
+        : `Students/${abbr}/${k}`
+    return (
+      <Box key={k} mb={2}>
+        <Typography variant="subtitle2">{LABELS[k]}</Typography>
+        {k === 'baseRate' ? (
+          <Typography variant="h6">
+            {v != null ? formatCurrency(Number(v)) : '-'}
+          </Typography>
+        ) : (
+          <InlineEdit
+            value={v}
+            fieldPath={path}
+            fieldKey={k}
+            editable={!['balanceDue', 'voucherBalance'].includes(k)}
+            serviceMode={serviceMode}
+            type={k.includes('Date') ? 'date' : 'text'}
+          />
+        )}
+      </Box>
+    )
+  }
+
   return (
     <Box>
-      {Object.entries(billing)
-        .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => {
-          const path =
-            k === 'defaultBillingType'
-              ? `Students/${abbr}/billingType`
-              : `Students/${abbr}/${k}`
-          return (
-            <Box key={k} mb={2}>
-              <Typography variant="subtitle2">{LABELS[k]}</Typography>
-              {k === 'baseRate' ? (
-                <Typography variant="h6">{
-                  v != null ? formatCurrency(Number(v)) : '-'
-                }</Typography>
-              ) : (
-                <InlineEdit
-                  value={v}
-                  fieldPath={path}
-                  fieldKey={k}
-                  editable={!['balanceDue', 'voucherBalance'].includes(k)}
-                  serviceMode={serviceMode}
-                  type={k.includes('Date') ? 'date' : 'text'}
-                />
-              )}
-            </Box>
-          )
-        })}
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Billing Information
+      </Typography>
+      {['balanceDue', 'baseRate', 'retainerStatus', 'lastPaymentDate', 'voucherBalance'].map(renderField)}
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
+        Payment Information
+      </Typography>
+      {['defaultBillingType', 'billingCompany'].map(renderField)}
     </Box>
   )
 }

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -332,6 +332,7 @@ export default function OverviewTab({
                 ) : (
                   <SessionsTab
                     sessions={sessions}
+                    jointDate={overview.joint}
                     lastSession={overview.last}
                     totalSessions={overview.total}
                   />

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -77,7 +77,6 @@ export default function OverviewTab({
     let mounted = true
 
     const loadLatest = async (col: string) => {
-      console.log(`📥 fetching ${abbr}/${col}`)
       let collectionName = col
       let field = col
       if (col === 'baseRate') {
@@ -100,7 +99,6 @@ export default function OverviewTab({
         return ''
       }
       const val = (snap.docs[0].data() as any)[field]
-      console.log(`✅ ${abbr} ${col}=${val}`)
       return val
     }
 
@@ -136,11 +134,9 @@ export default function OverviewTab({
       const fullName = `${personal.firstName || ''} ${
         personal.lastName || ''
       }`.trim()
-      console.log(`📥 sessions for ${fullName}`)
       const snap = await getDocs(
         query(collection(db, 'Sessions'), where('sessionName', '==', fullName))
       )
-      console.log(`   found ${snap.size} sessions`)
       const dates = await Promise.all(
         snap.docs.map(async (sd) => {
           const h = await getDocs(
@@ -151,7 +147,6 @@ export default function OverviewTab({
               limit(1)
             )
           )
-          console.log(`   history entries for ${sd.id}: ${h.size}`)
           if (!h.empty) {
             const d = h.docs[0].data() as any
             return (d.newDate?.toDate() || d.origDate.toDate()) as Date
@@ -167,6 +162,7 @@ export default function OverviewTab({
         total: sorted.length,
         upcoming: sorted.filter((d) => d > now).length,
         joint: sorted[0]?.toLocaleDateString() || '',
+        last: sorted[sorted.length - 1]?.toLocaleDateString() || '',
       })
       setOverviewLoading(false)
 
@@ -253,7 +249,7 @@ export default function OverviewTab({
                   </Typography>
 
                   <Typography variant="subtitle2">
-                    Sex{' '}
+                    Gender{' '}
                     {personalLoading.sex && <CircularProgress size={14} />}
                   </Typography>
                   {personalLoading.sex ? (
@@ -325,6 +321,8 @@ export default function OverviewTab({
                 <PersonalTab
                   abbr={abbr}
                   personal={personal}
+                  jointDate={overview.joint}
+                  totalSessions={overview.total}
                   serviceMode={serviceMode}
                 />
               )}
@@ -332,7 +330,11 @@ export default function OverviewTab({
                 sessionsLoading ? (
                   <CircularProgress />
                 ) : (
-                  <SessionsTab sessions={sessions} />
+                  <SessionsTab
+                    sessions={sessions}
+                    lastSession={overview.last}
+                    totalSessions={overview.total}
+                  />
                 )
               )}
               {tab === 3 && (

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -130,12 +130,8 @@ export default function OverviewTab({
 
     // overview counts + sessions
     ;(async () => {
-      // wait until names resolved
-      const fullName = `${personal.firstName || ''} ${
-        personal.lastName || ''
-      }`.trim()
       const snap = await getDocs(
-        query(collection(db, 'Sessions'), where('sessionName', '==', fullName))
+        query(collection(db, 'Sessions'), where('sessionName', '==', account))
       )
       const dates = await Promise.all(
         snap.docs.map(async (sd) => {
@@ -205,7 +201,7 @@ export default function OverviewTab({
     return () => {
       mounted = false
     }
-  }, [open, abbr, personal.firstName, personal.lastName])
+  }, [open, abbr, account])
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -272,7 +268,9 @@ export default function OverviewTab({
                   {overviewLoading ? (
                     <Typography variant="h6">Loading…</Typography>
                   ) : (
-                    <Typography variant="h6">{overview.joint}</Typography>
+                    <Typography variant="h6">
+                      {overview.joint || '–'}
+                    </Typography>
                   )}
 
                   <Typography variant="subtitle2">
@@ -283,10 +281,8 @@ export default function OverviewTab({
                     <Typography variant="h6">Loading…</Typography>
                   ) : (
                     <Typography variant="h6">
-                      {overview.total}
-                      {overview.upcoming > 0
-                        ? ` → ${overview.upcoming}`
-                        : ''}
+                      {overview.total ?? '–'}
+                      {overview.upcoming > 0 ? ` → ${overview.upcoming}` : ''}
                     </Typography>
                   )}
 

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -7,17 +7,21 @@ import InlineEdit from '../../common/InlineEdit'
 const LABELS: Record<string, string> = {
   firstName: 'First Name',
   lastName: 'Last Name',
-  sex: 'Sex',
+  sex: 'Gender',
   birthDate: 'Birth Date',
 }
 
 export default function PersonalTab({
   abbr,
   personal,
+  jointDate,
+  totalSessions,
   serviceMode,
 }: {
   abbr: string
   personal: any
+  jointDate?: string
+  totalSessions?: number
   serviceMode: boolean
 }) {
   return (
@@ -41,6 +45,18 @@ export default function PersonalTab({
             </Box>
           )
         })}
+      {jointDate && (
+        <Box mb={2}>
+          <Typography variant="subtitle2">Joint Date</Typography>
+          <Typography variant="h6">{jointDate}</Typography>
+        </Box>
+      )}
+      {totalSessions != null && (
+        <Box mb={2}>
+          <Typography variant="subtitle2">Total Sessions</Typography>
+          <Typography variant="h6">{totalSessions}</Typography>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -47,7 +47,7 @@ export default function PersonalTab({
         })}
       <Box mb={2}>
         <Typography variant="subtitle2">Joint Date</Typography>
-        <Typography variant="h6">{jointDate ?? '–'}</Typography>
+        <Typography variant="h6">{jointDate || '–'}</Typography>
       </Box>
       <Box mb={2}>
         <Typography variant="subtitle2">Total Sessions</Typography>

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -45,18 +45,14 @@ export default function PersonalTab({
             </Box>
           )
         })}
-      {jointDate && (
-        <Box mb={2}>
-          <Typography variant="subtitle2">Joint Date</Typography>
-          <Typography variant="h6">{jointDate}</Typography>
-        </Box>
-      )}
-      {totalSessions != null && (
-        <Box mb={2}>
-          <Typography variant="subtitle2">Total Sessions</Typography>
-          <Typography variant="h6">{totalSessions}</Typography>
-        </Box>
-      )}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Joint Date</Typography>
+        <Typography variant="h6">{jointDate ?? '–'}</Typography>
+      </Box>
+      <Box mb={2}>
+        <Typography variant="subtitle2">Total Sessions</Typography>
+        <Typography variant="h6">{totalSessions ?? '–'}</Typography>
+      </Box>
     </Box>
   )
 }

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -32,11 +32,11 @@ export default function SessionsTab({
       <Box mb={2}>
         <Box mb={1}>
           <Typography variant="subtitle2">Joint Date:</Typography>
-          <Typography variant="h6">{jointDate ?? '–'}</Typography>
+          <Typography variant="h6">{jointDate || '–'}</Typography>
         </Box>
         <Box mb={1}>
           <Typography variant="subtitle2">Last Session:</Typography>
-          <Typography variant="h6">{lastSession ?? '–'}</Typography>
+          <Typography variant="h6">{lastSession || '–'}</Typography>
         </Box>
         <Box mb={1}>
           <Typography variant="subtitle2">Total Sessions:</Typography>

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -29,28 +29,20 @@ export default function SessionsTab({
 }) {
   return (
     <>
-      {(jointDate || lastSession || totalSessions != null) && (
-        <Box mb={2}>
-          {jointDate && (
-            <Box mb={1}>
-              <Typography variant="subtitle2">Joint Date:</Typography>
-              <Typography variant="h6">{jointDate}</Typography>
-            </Box>
-          )}
-          {lastSession && (
-            <Box mb={1}>
-              <Typography variant="subtitle2">Last Session:</Typography>
-              <Typography variant="h6">{lastSession}</Typography>
-            </Box>
-          )}
-          {totalSessions != null && (
-            <Box mb={1}>
-              <Typography variant="subtitle2">Total Sessions:</Typography>
-              <Typography variant="h6">{totalSessions}</Typography>
-            </Box>
-          )}
+      <Box mb={2}>
+        <Box mb={1}>
+          <Typography variant="subtitle2">Joint Date:</Typography>
+          <Typography variant="h6">{jointDate ?? '–'}</Typography>
         </Box>
-      )}
+        <Box mb={1}>
+          <Typography variant="subtitle2">Last Session:</Typography>
+          <Typography variant="h6">{lastSession ?? '–'}</Typography>
+        </Box>
+        <Box mb={1}>
+          <Typography variant="subtitle2">Total Sessions:</Typography>
+          <Typography variant="h6">{totalSessions ?? '–'}</Typography>
+        </Box>
+      </Box>
       <Table size="small">
       <TableHead>
         <TableRow>

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -18,17 +18,25 @@ import {
 
 export default function SessionsTab({
   sessions,
+  jointDate,
   lastSession,
   totalSessions,
 }: {
   sessions: any[]
+  jointDate?: string
   lastSession?: string
   totalSessions?: number
 }) {
   return (
     <>
-      {(lastSession || totalSessions != null) && (
+      {(jointDate || lastSession || totalSessions != null) && (
         <Box mb={2}>
+          {jointDate && (
+            <>
+              <Typography variant="subtitle2">Joint Date:</Typography>
+              <Typography variant="h6">{jointDate}</Typography>
+            </>
+          )}
           {lastSession && (
             <>
               <Typography variant="subtitle2">Last Session:</Typography>

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -32,22 +32,22 @@ export default function SessionsTab({
       {(jointDate || lastSession || totalSessions != null) && (
         <Box mb={2}>
           {jointDate && (
-            <>
+            <Box mb={1}>
               <Typography variant="subtitle2">Joint Date:</Typography>
               <Typography variant="h6">{jointDate}</Typography>
-            </>
+            </Box>
           )}
           {lastSession && (
-            <>
+            <Box mb={1}>
               <Typography variant="subtitle2">Last Session:</Typography>
               <Typography variant="h6">{lastSession}</Typography>
-            </>
+            </Box>
           )}
           {totalSessions != null && (
-            <>
+            <Box mb={1}>
               <Typography variant="subtitle2">Total Sessions:</Typography>
               <Typography variant="h6">{totalSessions}</Typography>
-            </>
+            </Box>
           )}
         </Box>
       )}

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -7,6 +7,8 @@ const formatCurrency = (n: number) =>
     n,
   )
 import {
+  Box,
+  Typography,
   Table,
   TableHead,
   TableRow,
@@ -14,9 +16,34 @@ import {
   TableBody,
 } from '@mui/material'
 
-export default function SessionsTab({ sessions }: { sessions: any[] }) {
+export default function SessionsTab({
+  sessions,
+  lastSession,
+  totalSessions,
+}: {
+  sessions: any[]
+  lastSession?: string
+  totalSessions?: number
+}) {
   return (
-    <Table size="small">
+    <>
+      {(lastSession || totalSessions != null) && (
+        <Box mb={2}>
+          {lastSession && (
+            <>
+              <Typography variant="subtitle2">Last Session:</Typography>
+              <Typography variant="h6">{lastSession}</Typography>
+            </>
+          )}
+          {totalSessions != null && (
+            <>
+              <Typography variant="subtitle2">Total Sessions:</Typography>
+              <Typography variant="h6">{totalSessions}</Typography>
+            </>
+          )}
+        </Box>
+      )}
+      <Table size="small">
       <TableHead>
         <TableRow>
           {[
@@ -50,5 +77,6 @@ export default function SessionsTab({ sessions }: { sessions: any[] }) {
         ))}
       </TableBody>
     </Table>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- label personal data with Gender instead of Sex
- display joint date and total session count in personal tab and overview
- compute last session date for sessions tab summary
- reorganize billing tab fields with new headers
- show last session and total sessions above the session table
- remove leftover debug logging

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a0c11d4988323b79aaed2d1077327