### PR TITLE
Refactor student dialog data flow and expand personal fields

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -13,3 +13,5 @@ Later we discovered the dialog could still hang when non-active tabs were not mo
 Another hang arose when the initial spinner replaced the entire tab layout. With the tabs unrendered, their effects never ran and the loading flags stayed `true`. The dialog now overlays the spinner while keeping all tabs mounted so those callbacks always clear the flags.
 
 Continuous reloads later surfaced when `OverviewTab` passed inline callbacks to the child tabs. Each render created new `onPersonal`, `onBilling`, and `onSummary` functions, triggering the children’s `useEffect` hooks repeatedly and re-fetching data in a loop. Memoizing these handlers with `useCallback` stabilised their references and stopped the dialog from constantly refreshing.
+
+The most recent reload loop traced to defining the error boundary inside `OverviewTab`. Because the boundary class was re-created on every render, React unmounted and remounted the entire dialog tree, resetting all loading flags and re-triggering data fetches. Moving the boundary to the module scope keeps its identity stable and prevents the dialog from restarting after each render.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,5 @@
 # Agent Guidelines
 
-Any empty strings or missing data fields retrieved from Firestore should never cause the web app to become unresponsive. Instead these fields must be displayed as either **Error** (when retrieval fails) or **404/Not Found** if not yet set. When a numeric or date value is unavailable simply display a dash (`-`).
+Any empty strings or missing data fields retrieved from Firestore should never cause the web app to become unresponsive. Empty string values must render as **N/A**, missing values as **404/Not Found**, and retrieval failures as **Error**. When a numeric or date value is unavailable simply display a dash (`-`).
 
 Date fields must be validated before calling `.toLocaleDateString()` or similar methods. Invalid or empty values should be ignored, and the UI should show a placeholder rather than throwing errors or becoming stuck.

--- a/AGENT.md
+++ b/AGENT.md
@@ -11,3 +11,5 @@ The student dialog spinner persisted because Vercel served an outdated bundle th
 Later we discovered the dialog could still hang when non-active tabs were not mounted. Conditional rendering prevented `PersonalTab`, `SessionsTab`, and `BillingTab` from firing their data-fetch effects, so the parent never cleared its loading flags. Always render all tabs and toggle visibility with CSS so their callbacks run and the spinner disappears.
 
 Another hang arose when the initial spinner replaced the entire tab layout. With the tabs unrendered, their effects never ran and the loading flags stayed `true`. The dialog now overlays the spinner while keeping all tabs mounted so those callbacks always clear the flags.
+
+Continuous reloads later surfaced when `OverviewTab` passed inline callbacks to the child tabs. Each render created new `onPersonal`, `onBilling`, and `onSummary` functions, triggering the children’s `useEffect` hooks repeatedly and re-fetching data in a loop. Memoizing these handlers with `useCallback` stabilised their references and stopped the dialog from constantly refreshing.

--- a/AGENT.md
+++ b/AGENT.md
@@ -9,3 +9,5 @@ Date fields must be validated before calling `.toLocaleDateString()` or similar 
 The student dialog spinner persisted because Vercel served an outdated bundle that lacked the latest loading-flag resets. Redeploying and hard-refreshing the browser resolved the issue. Version logs (`=== StudentDialog loaded version 1.1 ===`) remain temporarily to confirm deployments.
 
 Later we discovered the dialog could still hang when non-active tabs were not mounted. Conditional rendering prevented `PersonalTab`, `SessionsTab`, and `BillingTab` from firing their data-fetch effects, so the parent never cleared its loading flags. Always render all tabs and toggle visibility with CSS so their callbacks run and the spinner disappears.
+
+Another hang arose when the initial spinner replaced the entire tab layout. With the tabs unrendered, their effects never ran and the loading flags stayed `true`. The dialog now overlays the spinner while keeping all tabs mounted so those callbacks always clear the flags.

--- a/AGENT.md
+++ b/AGENT.md
@@ -7,3 +7,5 @@ Date fields must be validated before calling `.toLocaleDateString()` or similar 
 ## Debug Notes
 
 The student dialog spinner persisted because Vercel served an outdated bundle that lacked the latest loading-flag resets. Redeploying and hard-refreshing the browser resolved the issue. Version logs (`=== StudentDialog loaded version 1.1 ===`) remain temporarily to confirm deployments.
+
+Later we discovered the dialog could still hang when non-active tabs were not mounted. Conditional rendering prevented `PersonalTab`, `SessionsTab`, and `BillingTab` from firing their data-fetch effects, so the parent never cleared its loading flags. Always render all tabs and toggle visibility with CSS so their callbacks run and the spinner disappears.

--- a/AGENT.md
+++ b/AGENT.md
@@ -3,3 +3,7 @@
 Any empty strings or missing data fields retrieved from Firestore should never cause the web app to become unresponsive. Empty string values must render as **N/A**, missing values as **404/Not Found**, and retrieval failures as **Error**. When a numeric or date value is unavailable simply display a dash (`-`).
 
 Date fields must be validated before calling `.toLocaleDateString()` or similar methods. Invalid or empty values should be ignored, and the UI should show a placeholder rather than throwing errors or becoming stuck.
+
+## Debug Notes
+
+The student dialog spinner persisted because Vercel served an outdated bundle that lacked the latest loading-flag resets. Redeploying and hard-refreshing the browser resolved the issue. Version logs (`=== StudentDialog loaded version 1.1 ===`) remain temporarily to confirm deployments.

--- a/README.md
+++ b/README.md
@@ -53,4 +53,8 @@ Field numbers are:
 
 Each document stores only the edited value and a `timestamp` so the full history
 can be tracked.
+
+## Placeholder Display
+
+When values are not available from Firestore the UI must remain responsive and show placeholders instead of failing. Empty strings render as **N/A**, missing values as **404 Not Found** and retrieval errors as **Error**. Numeric or date values that are unavailable should display a dash (`-`).
  

--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -13,6 +13,7 @@ export interface InlineEditProps {
   serviceMode?: boolean
   type: 'text' | 'number' | 'date' | 'select'
   options?: string[]
+  onSaved?: (v: any) => void
 }
 
 export default function InlineEdit({
@@ -23,6 +24,7 @@ export default function InlineEdit({
   serviceMode = false,
   type,
   options,
+  onSaved,
 }: InlineEditProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value)
@@ -67,6 +69,7 @@ export default function InlineEdit({
         timestamp: today,
       })
       setDraft(v)
+      onSaved?.(v)
     } catch (e) {
       console.error('Save failed', e)
     }
@@ -93,8 +96,15 @@ export default function InlineEdit({
   }
 
   const display = () => {
-    if (type === 'date' && draft) return new Date(draft).toLocaleDateString()
-    return String(draft ?? '')
+    if (draft === '__ERROR__') return 'Error'
+    if (draft === undefined) return '404 Not Found'
+    if (draft === '' || draft === null)
+      return type === 'number' || type === 'date' ? '-' : 'N/A'
+    if (type === 'date') {
+      const d = new Date(draft)
+      return isNaN(d.getTime()) ? '-' : d.toLocaleDateString()
+    }
+    return String(draft)
   }
 
   // when Service Mode is ON, disable edits and clicking shows full audit trail

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -30,11 +30,13 @@ export default function BillingTab({
   account,
   serviceMode,
   onBilling,
+  style,
 }: {
   abbr: string
   account: string
   serviceMode: boolean
   onBilling?: (b: Partial<{ balanceDue: number; voucherBalance: number }>) => void
+  style?: React.CSSProperties
 }) {
   console.log('Rendering BillingTab for', abbr)
   const [fields, setFields] = useState<any>({})
@@ -253,7 +255,7 @@ export default function BillingTab({
   }
 
   return (
-    <Box>
+    <Box style={style} sx={{ textAlign: 'left' }}>
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Billing Information
       </Typography>

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -6,6 +6,8 @@ import { collection, getDocs, query, where, orderBy, limit } from 'firebase/fire
 import { db } from '../../lib/firebase'
 import InlineEdit from '../../common/InlineEdit'
 
+console.log('=== StudentDialog loaded version 1.1 ===')
+
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
 
@@ -34,6 +36,7 @@ export default function BillingTab({
   serviceMode: boolean
   onBilling?: (b: Partial<{ balanceDue: number; voucherBalance: number }>) => void
 }) {
+  console.log('Rendering BillingTab for', abbr)
   const [fields, setFields] = useState<any>({})
   const [loading, setLoading] = useState<any>({
     billingCompany: true,
@@ -58,6 +61,7 @@ export default function BillingTab({
   }
 
   useEffect(() => {
+    console.log('BillingTab effect: load simple fields for', abbr)
     let cancelled = false
     ;(async () => {
       const simple = [
@@ -102,6 +106,7 @@ export default function BillingTab({
   }, [abbr, onBilling])
 
   useEffect(() => {
+    console.log('BillingTab effect: calculate balance due for', abbr)
     // Balance Due calculation
     let cancelled = false
     ;(async () => {

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -1,15 +1,13 @@
 // components/StudentDialog/BillingTab.tsx
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Typography } from '@mui/material'
-import { collection, getDocs, query, where, orderBy } from 'firebase/firestore'
+import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
+import InlineEdit from '../../common/InlineEdit'
 
 const formatCurrency = (n: number) =>
-  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(
-    n,
-  )
-import InlineEdit from '../../common/InlineEdit'
+  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
 
 const LABELS: Record<string, string> = {
   billingCompany: 'Billing Company Info',
@@ -21,21 +19,90 @@ const LABELS: Record<string, string> = {
   voucherBalance: 'Voucher Balance',
 }
 
+// BillingTab owns all billing-related fetching and calculations. It streams
+// summary values (Balance Due, Voucher Balance) up to OverviewTab via
+// `onBilling`.
+
 export default function BillingTab({
   abbr,
   account,
-  billing,
   serviceMode,
-  onBalanceDue,
+  onBilling,
 }: {
   abbr: string
   account: string
-  billing: any
   serviceMode: boolean
-  onBalanceDue?: (n: number) => void
+  onBilling?: (b: Partial<{ balanceDue: number; voucherBalance: number }>) => void
 }) {
+  const [fields, setFields] = useState<any>({})
+  const [loading, setLoading] = useState<any>({
+    billingCompany: true,
+    defaultBillingType: true,
+    baseRate: true,
+    retainerStatus: true,
+    lastPaymentDate: true,
+    balanceDue: true,
+    voucherBalance: true,
+  })
+
+  const loadLatest = async (sub: string, field: string) => {
+    try {
+      const snap = await getDocs(
+        query(collection(db, 'Students', abbr, sub), orderBy('timestamp', 'desc'), limit(1)),
+      )
+      return snap.empty ? undefined : (snap.docs[0].data() as any)[field]
+    } catch (e) {
+      console.error(`load ${sub} failed`, e)
+      return '__ERROR__'
+    }
+  }
+
   useEffect(() => {
-    // BillingTab owns Balance Due calculation; OverviewTab consumes the result
+    let cancelled = false
+    ;(async () => {
+      const simple = [
+        'billingCompany',
+        'defaultBillingType',
+        'baseRate',
+        'retainerStatus',
+        'lastPaymentDate',
+        'voucherBalance',
+      ]
+      for (const f of simple) {
+        try {
+          const val: any = await loadLatest(
+            f === 'defaultBillingType' ? 'billingType' : f,
+            f === 'baseRate' ? 'rate' : f,
+          )
+          if (cancelled) return
+          setFields((b: any) => ({ ...b, [f]: val }))
+          setLoading((l: any) => {
+            const next = { ...l, [f]: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          if (f === 'voucherBalance')
+            onBilling?.({ voucherBalance: typeof val === 'number' ? val : undefined })
+        } catch (e) {
+          console.error(`${f} load failed`, e)
+          if (cancelled) return
+          setFields((b: any) => ({ ...b, [f]: '__ERROR__' }))
+          setLoading((l: any) => {
+            const next = { ...l, [f]: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          if (f === 'voucherBalance') onBilling?.({ voucherBalance: undefined })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [abbr, onBilling])
+
+  useEffect(() => {
+    // Balance Due calculation
     let cancelled = false
     ;(async () => {
       try {
@@ -56,12 +123,7 @@ export default function BillingTab({
 
         const [baseRateSnap, paymentSnap, sessionRows] = await Promise.all([
           getDocs(collection(db, 'Students', abbr, 'BaseRateHistory')),
-          getDocs(
-            query(
-              collection(db, 'Students', abbr, 'Payments'),
-              orderBy('paymentMade'),
-            ),
-          ),
+          getDocs(query(collection(db, 'Students', abbr, 'Payments'), orderBy('paymentMade'))),
           Promise.all(rowPromises),
         ])
 
@@ -87,10 +149,8 @@ export default function BillingTab({
           const hist = history
             .slice()
             .sort((a: any, b: any) => {
-              const ta =
-                parseDate(a.changeTimestamp) || parseDate(a.timestamp) || new Date(0)
-              const tb =
-                parseDate(b.changeTimestamp) || parseDate(b.timestamp) || new Date(0)
+              const ta = parseDate(a.changeTimestamp) || parseDate(a.timestamp) || new Date(0)
+              const tb = parseDate(b.changeTimestamp) || parseDate(b.timestamp) || new Date(0)
               return tb.getTime() - ta.getTime()
             })[0]
           if (!hist) {
@@ -106,9 +166,7 @@ export default function BillingTab({
           }
           const base = (() => {
             if (!baseRates.length) return '-'
-            const entry = baseRates
-              .filter((b) => b.ts.getTime() <= startDate.getTime())
-              .pop()
+            const entry = baseRates.filter((b) => b.ts.getTime() <= startDate.getTime()).pop()
             return entry ? entry.rate : '-'
           })()
           const rateHist = rateDocs
@@ -120,8 +178,7 @@ export default function BillingTab({
             })
           const latestRate = rateHist[0]?.rateCharged
           const rateCharged = latestRate != null ? Number(latestRate) : base
-          if (rateCharged != null && !isNaN(Number(rateCharged)))
-            totalOwed += Number(rateCharged)
+          if (rateCharged != null && !isNaN(Number(rateCharged))) totalOwed += Number(rateCharged)
         })
 
         const totalPaid = paymentSnap.docs.reduce((sum, d) => {
@@ -130,18 +187,35 @@ export default function BillingTab({
         }, 0)
 
         const balanceDue = totalOwed - totalPaid
-        if (!cancelled) onBalanceDue?.(balanceDue)
+        if (!cancelled) {
+          setFields((b: any) => ({ ...b, balanceDue }))
+          setLoading((l: any) => {
+            const next = { ...l, balanceDue: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          onBilling?.({ balanceDue })
+        }
       } catch (e) {
         console.error('balance due calculation failed', e)
-        if (!cancelled) onBalanceDue?.(0)
+        if (!cancelled) {
+          setFields((b: any) => ({ ...b, balanceDue: 0 }))
+          setLoading((l: any) => {
+            const next = { ...l, balanceDue: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          onBilling?.({ balanceDue: 0 })
+        }
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [abbr, account, onBalanceDue])
+  }, [abbr, account, onBilling])
+
   const renderField = (k: string) => {
-    const v = billing[k]
+    const v = fields[k]
     const path =
       k === 'defaultBillingType'
         ? `Students/${abbr}/billingType`
@@ -149,11 +223,11 @@ export default function BillingTab({
     return (
       <Box key={k} mb={2}>
         <Typography variant="subtitle2">{LABELS[k]}</Typography>
-        {k === 'baseRate' ? (
+        {loading[k] ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : k === 'baseRate' ? (
           <Typography variant="h6">
-            {v != null && !isNaN(Number(v))
-              ? `${formatCurrency(Number(v))} / session`
-              : '-'}
+            {v != null && !isNaN(Number(v)) ? `${formatCurrency(Number(v))} / session` : '-'}
           </Typography>
         ) : (
           <InlineEdit
@@ -163,6 +237,10 @@ export default function BillingTab({
             editable={!['balanceDue', 'voucherBalance'].includes(k)}
             serviceMode={serviceMode}
             type={k.includes('Date') ? 'date' : 'text'}
+            onSaved={(val) => {
+              setFields((b: any) => ({ ...b, [k]: val }))
+              if (k === 'voucherBalance') onBilling?.({ voucherBalance: Number(val) })
+            }}
           />
         )}
       </Box>
@@ -174,11 +252,14 @@ export default function BillingTab({
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Billing Information
       </Typography>
-      {['balanceDue', 'baseRate', 'retainerStatus', 'lastPaymentDate', 'voucherBalance'].map(renderField)}
+      {['balanceDue', 'baseRate', 'retainerStatus', 'lastPaymentDate', 'voucherBalance'].map(
+        (k) => renderField(k),
+      )}
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
         Payment Information
       </Typography>
-      {['defaultBillingType', 'billingCompany'].map(renderField)}
+      {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
     </Box>
   )
 }
+

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -234,30 +234,27 @@ export default function OverviewTab({
                 )}
               </Box>
 
-              <Box sx={{ display: tab === 1 ? 'block' : 'none' }}>
-                <PersonalTab
-                  abbr={abbr}
-                  serviceMode={serviceMode}
-                  onPersonal={handlePersonal}
-                />
-              </Box>
+              <PersonalTab
+                abbr={abbr}
+                serviceMode={serviceMode}
+                onPersonal={handlePersonal}
+                style={{ display: tab === 1 ? 'block' : 'none' }}
+              />
 
-              <Box sx={{ display: tab === 2 ? 'block' : 'none' }}>
-                <SessionsTab
-                  abbr={abbr}
-                  account={account}
-                  onSummary={handleSummary}
-                />
-              </Box>
+              <SessionsTab
+                abbr={abbr}
+                account={account}
+                onSummary={handleSummary}
+                style={{ display: tab === 2 ? 'block' : 'none' }}
+              />
 
-              <Box sx={{ display: tab === 3 ? 'block' : 'none' }}>
-                <BillingTab
-                  abbr={abbr}
-                  account={account}
-                  serviceMode={serviceMode}
-                  onBilling={handleBilling}
-                />
-              </Box>
+              <BillingTab
+                abbr={abbr}
+                account={account}
+                serviceMode={serviceMode}
+                onBilling={handleBilling}
+                style={{ display: tab === 3 ? 'block' : 'none' }}
+              />
             </Box>
 
             <Tabs

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -25,6 +25,29 @@ import SessionsTab from './SessionsTab'
 
 console.log('=== StudentDialog loaded version 1.1 ===')
 
+class StudentDialogErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null }
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('StudentDialog render error', error, info)
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <Box p={2}>
+          <Typography color="error">Student dialog failed to load.</Typography>
+        </Box>
+      )
+    }
+    return this.props.children
+  }
+}
+
 export interface OverviewTabProps {
   abbr: string
   account: string
@@ -123,26 +146,6 @@ export default function OverviewTab({
     Object.values(personalLoading).some((v) => v) ||
     Object.values(billingLoading).some((v) => v) ||
     overviewLoading
-
-  class StudentDialogErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
-    state = { error: null as Error | null }
-    static getDerivedStateFromError(error: Error) {
-      return { error }
-    }
-    componentDidCatch(error: Error, info: React.ErrorInfo) {
-      console.error('StudentDialog render error', error, info)
-    }
-    render() {
-      if (this.state.error) {
-        return (
-          <Box p={2}>
-            <Typography color="error">Student dialog failed to load.</Typography>
-          </Box>
-        )
-      }
-      return this.props.children
-    }
-  }
 
   return (
     <StudentDialogErrorBoundary>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -139,141 +139,142 @@ export default function OverviewTab({
     <StudentDialogErrorBoundary>
       <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ textAlign: 'left' }}>{account}</DialogTitle>
-      <DialogContent sx={{ display: 'flex', height: '70vh' }}>
-        {loading ? (
+      <DialogContent sx={{ display: 'flex', height: '70vh', position: 'relative' }}>
+        {loading && (
           <Box
             sx={{
-              flexGrow: 1,
+              position: 'absolute',
+              inset: 0,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
+              bgcolor: 'background.paper',
+              zIndex: 1,
             }}
           >
             <CircularProgress />
           </Box>
-        ) : (
-          <>
-            <Box
-              sx={{
-                flexGrow: 1,
-                pr: 3,
-                overflowY: 'auto',
-                textAlign: 'left',
-              }}
-            >
-              <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
-                <Typography variant="subtitle2">
-                  Legal Name{' '}
-                  {(personalLoading.firstName || personalLoading.lastName) && (
-                    <CircularProgress size={14} />
-                  )}
-                </Typography>
-                <Typography variant="h6">
-                  {(personalLoading.firstName || personalLoading.lastName)
-                    ? 'Loading…'
-                    : (() => {
-                        const first = displayField(personal.firstName)
-                        const last = displayField(personal.lastName)
-                        const both = `${first} ${last}`.trim()
-                        return both === '404 Not Found 404 Not Found'
-                          ? '404 Not Found'
-                          : both
-                      })()}
-                </Typography>
-
-                <Typography variant="subtitle2">
-                  Gender {personalLoading.sex && <CircularProgress size={14} />}
-                </Typography>
-                <Typography variant="h6">
-                  {personalLoading.sex
-                    ? 'Loading…'
-                    : displayField(personal.sex)}
-                </Typography>
-
-                <Typography variant="subtitle2">
-                  Joint Date {overviewLoading && <CircularProgress size={14} />}
-                </Typography>
-                {overviewLoading ? (
-                  <Typography variant="h6">Loading…</Typography>
-                ) : (
-                  <Typography variant="h6">{overview.joint || '–'}</Typography>
-                )}
-
-                <Typography variant="subtitle2">
-                  Total Sessions {overviewLoading && <CircularProgress size={14} />}
-                </Typography>
-                {overviewLoading ? (
-                  <Typography variant="h6">Loading…</Typography>
-                ) : (
-                  <Typography variant="h6">{overview.total ?? '–'}</Typography>
-                )}
-
-                <Typography variant="subtitle2">
-                  Balance Due {billingLoading.balanceDue && <CircularProgress size={14} />}
-                </Typography>
-                {billingLoading.balanceDue ? (
-                  <Typography variant="h6">Loading…</Typography>
-                ) : (
-                  <Typography variant="h6">
-                    {billing.balanceDue != null
-                      ? `$${(Number(billing.balanceDue) || 0).toFixed(2)}`
-                      : '-'}
-                  </Typography>
-                )}
-
-                <Typography variant="subtitle2">
-                  Session Voucher{' '}
-                  {billingLoading.voucherBalance && <CircularProgress size={14} />}
-                </Typography>
-                {billingLoading.voucherBalance ? (
-                  <Typography variant="h6">Loading…</Typography>
-                ) : (
-                  <Typography variant="h6">
-                    {billing.voucherBalance ?? '-'}
-                  </Typography>
-                )}
-              </Box>
-
-              <PersonalTab
-                abbr={abbr}
-                serviceMode={serviceMode}
-                onPersonal={handlePersonal}
-                style={{ display: tab === 1 ? 'block' : 'none' }}
-              />
-
-              <SessionsTab
-                abbr={abbr}
-                account={account}
-                onSummary={handleSummary}
-                style={{ display: tab === 2 ? 'block' : 'none' }}
-              />
-
-              <BillingTab
-                abbr={abbr}
-                account={account}
-                serviceMode={serviceMode}
-                onBilling={handleBilling}
-                style={{ display: tab === 3 ? 'block' : 'none' }}
-              />
-            </Box>
-
-            <Tabs
-              orientation="vertical"
-              value={tab}
-              onChange={(_, v) => setTab(v)}
-              sx={{
-                borderLeft: 1,
-                borderColor: 'divider',
-                minWidth: 140,
-                alignItems: 'flex-end',
-              }}
-            >
-              {['Overview', 'Personal', 'Sessions', 'Billing'].map((l) => (
-                <Tab key={l} label={l} sx={{ textAlign: 'right' }} />
-              ))}
-            </Tabs>
-          </>
         )}
+
+        <Box
+          sx={{
+            flexGrow: 1,
+            pr: 3,
+            overflowY: 'auto',
+            textAlign: 'left',
+            display: loading ? 'none' : 'block',
+          }}
+        >
+          <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
+            <Typography variant="subtitle2">
+              Legal Name{' '}
+              {(personalLoading.firstName || personalLoading.lastName) && (
+                <CircularProgress size={14} />
+              )}
+            </Typography>
+            <Typography variant="h6">
+              {(personalLoading.firstName || personalLoading.lastName)
+                ? 'Loading…'
+                : (() => {
+                    const first = displayField(personal.firstName)
+                    const last = displayField(personal.lastName)
+                    const both = `${first} ${last}`.trim()
+                    return both === '404 Not Found 404 Not Found'
+                      ? '404 Not Found'
+                      : both
+                  })()}
+            </Typography>
+
+            <Typography variant="subtitle2">
+              Gender {personalLoading.sex && <CircularProgress size={14} />}
+            </Typography>
+            <Typography variant="h6">
+              {personalLoading.sex
+                ? 'Loading…'
+                : displayField(personal.sex)}
+            </Typography>
+
+            <Typography variant="subtitle2">
+              Joint Date {overviewLoading && <CircularProgress size={14} />}
+            </Typography>
+            {overviewLoading ? (
+              <Typography variant="h6">Loading…</Typography>
+            ) : (
+              <Typography variant="h6">{overview.joint || '–'}</Typography>
+            )}
+
+            <Typography variant="subtitle2">
+              Total Sessions {overviewLoading && <CircularProgress size={14} />}
+            </Typography>
+            {overviewLoading ? (
+              <Typography variant="h6">Loading…</Typography>
+            ) : (
+              <Typography variant="h6">{overview.total ?? '–'}</Typography>
+            )}
+
+            <Typography variant="subtitle2">
+              Balance Due {billingLoading.balanceDue && <CircularProgress size={14} />}
+            </Typography>
+            {billingLoading.balanceDue ? (
+              <Typography variant="h6">Loading…</Typography>
+            ) : (
+              <Typography variant="h6">
+                {billing.balanceDue != null
+                  ? `$${(Number(billing.balanceDue) || 0).toFixed(2)}`
+                  : '-'}
+              </Typography>
+            )}
+
+            <Typography variant="subtitle2">
+              Session Voucher{' '}
+              {billingLoading.voucherBalance && <CircularProgress size={14} />}
+            </Typography>
+            {billingLoading.voucherBalance ? (
+              <Typography variant="h6">Loading…</Typography>
+            ) : (
+              <Typography variant="h6">{billing.voucherBalance ?? '-'}</Typography>
+            )}
+          </Box>
+
+          <PersonalTab
+            abbr={abbr}
+            serviceMode={serviceMode}
+            onPersonal={handlePersonal}
+            style={{ display: tab === 1 ? 'block' : 'none' }}
+          />
+
+          <SessionsTab
+            abbr={abbr}
+            account={account}
+            onSummary={handleSummary}
+            style={{ display: tab === 2 ? 'block' : 'none' }}
+          />
+
+          <BillingTab
+            abbr={abbr}
+            account={account}
+            serviceMode={serviceMode}
+            onBilling={handleBilling}
+            style={{ display: tab === 3 ? 'block' : 'none' }}
+          />
+        </Box>
+
+        <Tabs
+          orientation="vertical"
+          value={tab}
+          onChange={(_, v) => setTab(v)}
+          sx={{
+            borderLeft: 1,
+            borderColor: 'divider',
+            minWidth: 140,
+            alignItems: 'flex-end',
+            display: loading ? 'none' : 'flex',
+          }}
+        >
+          {['Overview', 'Personal', 'Sessions', 'Billing'].map((l) => (
+            <Tab key={l} label={l} sx={{ textAlign: 'right' }} />
+          ))}
+        </Tabs>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Close</Button>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -1,6 +1,6 @@
 // components/StudentDialog/OverviewTab.tsx
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -62,24 +62,33 @@ export default function OverviewTab({
   const [overview, setOverview] = useState<any>({ joint: '', last: '', total: 0 })
   const [overviewLoading, setOverviewLoading] = useState(true)
 
-  const handlePersonal = (data: Partial<{ firstName: string; lastName: string; sex: string }>) => {
-    setPersonal((p: any) => ({ ...p, ...data }))
-    Object.keys(data).forEach((k) =>
-      setPersonalLoading((l: any) => ({ ...l, [k]: false }))
-    )
-  }
+  const handlePersonal = useCallback(
+    (data: Partial<{ firstName: string; lastName: string; sex: string }>) => {
+      setPersonal((p: any) => ({ ...p, ...data }))
+      Object.keys(data).forEach((k) =>
+        setPersonalLoading((l: any) => ({ ...l, [k]: false }))
+      )
+    },
+    [setPersonal, setPersonalLoading],
+  )
 
-  const handleBilling = (data: Partial<{ balanceDue: number; voucherBalance: number }>) => {
-    setBilling((b: any) => ({ ...b, ...data }))
-    Object.keys(data).forEach((k) =>
-      setBillingLoading((l: any) => ({ ...l, [k]: false }))
-    )
-  }
+  const handleBilling = useCallback(
+    (data: Partial<{ balanceDue: number; voucherBalance: number }>) => {
+      setBilling((b: any) => ({ ...b, ...data }))
+      Object.keys(data).forEach((k) =>
+        setBillingLoading((l: any) => ({ ...l, [k]: false }))
+      )
+    },
+    [setBilling, setBillingLoading],
+  )
 
-  const handleSummary = (s: { jointDate: string; lastSession: string; totalSessions: number }) => {
-    setOverview({ joint: s.jointDate, last: s.lastSession, total: s.totalSessions })
-    setOverviewLoading(false)
-  }
+  const handleSummary = useCallback(
+    (s: { jointDate: string; lastSession: string; totalSessions: number }) => {
+      setOverview({ joint: s.jointDate, last: s.lastSession, total: s.totalSessions })
+      setOverviewLoading(false)
+    },
+    [setOverview, setOverviewLoading],
+  )
 
   // reset loading states whenever dialog is opened
   useEffect(() => {

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -23,6 +23,8 @@ import PersonalTab from './PersonalTab'
 import BillingTab from './BillingTab'
 import SessionsTab from './SessionsTab'
 
+console.log('=== StudentDialog loaded version 1.1 ===')
+
 export interface OverviewTabProps {
   abbr: string
   account: string
@@ -38,6 +40,7 @@ export default function OverviewTab({
   onClose,
   serviceMode,
 }: OverviewTabProps) {
+  console.log('OverviewTab rendered for', abbr)
   const [tab, setTab] = useState(0)
 
   // personal summary streamed from PersonalTab
@@ -80,6 +83,7 @@ export default function OverviewTab({
 
   // reset loading states whenever dialog is opened
   useEffect(() => {
+    console.log('OverviewTab reset effect for', abbr)
     if (open) {
       setPersonal({})
       setBilling({})
@@ -90,6 +94,14 @@ export default function OverviewTab({
       setTab(0)
     }
   }, [open])
+
+  useEffect(() => {
+    console.log('OverviewTab loading states', {
+      personalLoading,
+      billingLoading,
+      overviewLoading,
+    })
+  })
 
   const displayField = (v: any) => {
     if (v === '__ERROR__') return 'Error'
@@ -103,8 +115,29 @@ export default function OverviewTab({
     Object.values(billingLoading).some((v) => v) ||
     overviewLoading
 
+  class StudentDialogErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
+    state = { error: null as Error | null }
+    static getDerivedStateFromError(error: Error) {
+      return { error }
+    }
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
+      console.error('StudentDialog render error', error, info)
+    }
+    render() {
+      if (this.state.error) {
+        return (
+          <Box p={2}>
+            <Typography color="error">Student dialog failed to load.</Typography>
+          </Box>
+        )
+      }
+      return this.props.children
+    }
+  }
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <StudentDialogErrorBoundary>
+      <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ textAlign: 'left' }}>{account}</DialogTitle>
       <DialogContent sx={{ display: 'flex', height: '70vh' }}>
         {loading ? (
@@ -248,6 +281,7 @@ export default function OverviewTab({
       <DialogActions>
         <Button onClick={onClose}>Close</Button>
       </DialogActions>
-    </Dialog>
+      </Dialog>
+    </StudentDialogErrorBoundary>
   )
 }

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -13,21 +13,12 @@ import {
   Typography,
   Button,
 } from '@mui/material'
-import {
-  collection,
-  getDocs,
-  getDoc,
-  doc,
-  query,
-  orderBy,
-  limit,
-} from 'firebase/firestore'
-import { db } from '../../lib/firebase'
 
-// OverviewTab displays summary values supplied by child tabs (PersonalTab,
-// SessionsTab, BillingTab). These children own their respective data fetching
-// and push updates here via callbacks, keeping OverviewTab as a pure presenter.
-import InlineEdit from '../../common/InlineEdit'
+// OverviewTab acts purely as a presenter. PersonalTab, SessionsTab and
+// BillingTab each fetch and compute their own data then "stream" summary
+// values upward via callbacks. OverviewTab never queries Firestore directly,
+// keeping a single source of truth in the owning tab and avoiding duplicated
+// logic across the dialog.
 import PersonalTab from './PersonalTab'
 import BillingTab from './BillingTab'
 import SessionsTab from './SessionsTab'
@@ -47,120 +38,70 @@ export default function OverviewTab({
   onClose,
   serviceMode,
 }: OverviewTabProps) {
-  const [loading, setLoading] = useState(true)
   const [tab, setTab] = useState(0)
 
-  // personal
+  // personal summary streamed from PersonalTab
   const [personal, setPersonal] = useState<any>({})
   const [personalLoading, setPersonalLoading] = useState({
     firstName: true,
     lastName: true,
     sex: true,
-    birthDate: true,
   })
 
-  // billing
+  // billing summary streamed from BillingTab
   const [billing, setBilling] = useState<any>({})
   const [billingLoading, setBillingLoading] = useState({
-    billingCompany: true,
-    defaultBillingType: true,
-    baseRate: true,
-    retainerStatus: true,
-    lastPaymentDate: true,
     balanceDue: true,
     voucherBalance: true,
   })
 
-  // overview + sessions
+  // overview summary streamed from SessionsTab
   const [overview, setOverview] = useState<any>({ joint: '', last: '', total: 0 })
   const [overviewLoading, setOverviewLoading] = useState(true)
 
-  const handleBalanceDue = (n: number) => {
-    setBilling((b: any) => ({ ...b, balanceDue: n }))
-    setBillingLoading((l) => ({ ...l, balanceDue: false }))
+  const handlePersonal = (data: Partial<{ firstName: string; lastName: string; sex: string }>) => {
+    setPersonal((p: any) => ({ ...p, ...data }))
+    Object.keys(data).forEach((k) =>
+      setPersonalLoading((l: any) => ({ ...l, [k]: false }))
+    )
   }
 
-  const handleSummary = (s: {
-    jointDate: string
-    lastSession: string
-    totalSessions: number
-  }) => {
+  const handleBilling = (data: Partial<{ balanceDue: number; voucherBalance: number }>) => {
+    setBilling((b: any) => ({ ...b, ...data }))
+    Object.keys(data).forEach((k) =>
+      setBillingLoading((l: any) => ({ ...l, [k]: false }))
+    )
+  }
+
+  const handleSummary = (s: { jointDate: string; lastSession: string; totalSessions: number }) => {
     setOverview({ joint: s.jointDate, last: s.lastSession, total: s.totalSessions })
+    setOverviewLoading(false)
   }
 
+  // reset loading states whenever dialog is opened
   useEffect(() => {
-    if (!open) return
-    let mounted = true
-
-    const loadLatest = async (col: string) => {
-      let collectionName = col
-      let field = col
-      if (col === 'baseRate') {
-        collectionName = 'BaseRateHistory'
-        field = 'rate'
-      }
-      if (col === 'defaultBillingType') {
-        collectionName = 'billingType'
-        field = 'billingType'
-      }
-      const snap = await getDocs(
-        query(
-          collection(db, 'Students', abbr, collectionName),
-          orderBy('timestamp', 'desc'),
-          limit(1)
-        )
-      )
-      if (snap.empty) {
-        console.warn(`⚠️ no ${col} for ${abbr}`)
-        return ''
-      }
-      const val = (snap.docs[0].data() as any)[field]
-      return val
+    if (open) {
+      setPersonal({})
+      setBilling({})
+      setOverview({ joint: '', last: '', total: 0 })
+      setPersonalLoading({ firstName: true, lastName: true, sex: true })
+      setBillingLoading({ balanceDue: true, voucherBalance: true })
+      setOverviewLoading(true)
+      setTab(0)
     }
+  }, [open])
 
-    // load personal fields
-    ;['firstName', 'lastName', 'sex', 'birthDate'].forEach((f) => {
-      loadLatest(f).then((v) => {
-        if (!mounted) return
-        setPersonal((p: any) => ({ ...p, [f]: v }))
-        setPersonalLoading((l) => ({ ...l, [f]: false }))
-      })
-    })
+  const displayField = (v: any) => {
+    if (v === '__ERROR__') return 'Error'
+    if (v === undefined) return '404 Not Found'
+    if (v === '') return 'N/A'
+    return String(v)
+  }
 
-    // load billing fields
-    ;[
-      'billingCompany',
-      'defaultBillingType',
-      'baseRate',
-      'retainerStatus',
-      'lastPaymentDate',
-      'voucherBalance',
-    ].forEach((f) => {
-      loadLatest(f).then((v) => {
-        if (!mounted) return
-        setBilling((b: any) => ({ ...b, [f]: v }))
-        setBillingLoading((l) => ({ ...l, [f]: false }))
-      })
-    })
-
-    // load overview summary from student profile
-    ;(async () => {
-      const studSnap = await getDoc(doc(db, 'Students', abbr))
-      const studData = studSnap.exists() ? (studSnap.data() as any) : {}
-      if (!mounted) return
-      setOverview({
-        joint: studData.jointDate || '',
-        last: studData.lastSession || '',
-        total: studData.totalSessions ?? 0,
-      })
-      setOverviewLoading(false)
-      setLoading(false)
-    })()
-
-    return () => {
-      mounted = false
-    }
-  }, [open, abbr, account])
+  const loading =
+    Object.values(personalLoading).some((v) => v) ||
+    Object.values(billingLoading).some((v) => v) ||
+    overviewLoading
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -197,24 +138,24 @@ export default function OverviewTab({
                 <Typography variant="h6">
                   {(personalLoading.firstName || personalLoading.lastName)
                     ? 'Loading…'
-                    : `${personal.firstName} ${personal.lastName}`}
+                    : (() => {
+                        const first = displayField(personal.firstName)
+                        const last = displayField(personal.lastName)
+                        const both = `${first} ${last}`.trim()
+                        return both === '404 Not Found 404 Not Found'
+                          ? '404 Not Found'
+                          : both
+                      })()}
                 </Typography>
 
                 <Typography variant="subtitle2">
                   Gender {personalLoading.sex && <CircularProgress size={14} />}
                 </Typography>
-                {personalLoading.sex ? (
-                  <Typography variant="h6">Loading…</Typography>
-                ) : (
-                  <InlineEdit
-                    value={personal.sex}
-                    fieldPath={`Students/${abbr}/sex`}
-                    fieldKey="sex"
-                    editable={serviceMode}
-                    type="select"
-                    options={['Male', 'Female', 'Other']}
-                  />
-                )}
+                <Typography variant="h6">
+                  {personalLoading.sex
+                    ? 'Loading…'
+                    : displayField(personal.sex)}
+                </Typography>
 
                 <Typography variant="subtitle2">
                   Joint Date {overviewLoading && <CircularProgress size={14} />}
@@ -255,7 +196,7 @@ export default function OverviewTab({
                   <Typography variant="h6">Loading…</Typography>
                 ) : (
                   <Typography variant="h6">
-                    {billing.voucherBalance ?? '0'}
+                    {billing.voucherBalance ?? '-'}
                   </Typography>
                 )}
               </Box>
@@ -263,10 +204,8 @@ export default function OverviewTab({
               <Box sx={{ display: tab === 1 ? 'block' : 'none' }}>
                 <PersonalTab
                   abbr={abbr}
-                  personal={personal}
-                  jointDate={overview.joint}
-                  totalSessions={overview.total}
                   serviceMode={serviceMode}
+                  onPersonal={handlePersonal}
                 />
               </Box>
 
@@ -274,9 +213,6 @@ export default function OverviewTab({
                 <SessionsTab
                   abbr={abbr}
                   account={account}
-                  jointDate={overview.joint}
-                  lastSession={overview.last}
-                  totalSessions={overview.total}
                   onSummary={handleSummary}
                 />
               </Box>
@@ -285,9 +221,8 @@ export default function OverviewTab({
                 <BillingTab
                   abbr={abbr}
                   account={account}
-                  billing={billing}
                   serviceMode={serviceMode}
-                  onBalanceDue={handleBalanceDue}
+                  onBilling={handleBilling}
                 />
               </Box>
             </Box>

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -1,58 +1,597 @@
 // components/StudentDialog/PersonalTab.tsx
 
-import React from 'react'
-import { Box, Typography } from '@mui/material'
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Typography,
+  TextField,
+  MenuItem,
+  Button,
+  Stack,
+} from '@mui/material'
 import InlineEdit from '../../common/InlineEdit'
+import { collection, getDocs, query, orderBy, limit, doc, setDoc } from 'firebase/firestore'
+import { db } from '../../lib/firebase'
 
-const LABELS: Record<string, string> = {
-  firstName: 'First Name',
-  lastName: 'Last Name',
-  sex: 'Gender',
-  birthDate: 'Birth Date',
-}
+// PersonalTab owns all personal information for a student. It fetches the
+// latest values from Firestore and streams key fields upward to OverviewTab via
+// `onPersonal` so OverviewTab can present them without duplicating logic.
+
+const REGION_OPTIONS = ['Hong Kong', 'Kowloon', 'New Territories']
 
 export default function PersonalTab({
   abbr,
-  personal,
-  jointDate,
-  totalSessions,
   serviceMode,
+  onPersonal,
 }: {
   abbr: string
-  personal: any
-  jointDate?: string
-  totalSessions?: number
   serviceMode: boolean
+  onPersonal?: (p: Partial<{ firstName: string; lastName: string; sex: string; birthDate: string }>) => void
 }) {
+  const [fields, setFields] = useState<any>({
+    firstName: undefined,
+    lastName: undefined,
+    sex: undefined,
+    birthDate: undefined,
+    hkid: undefined,
+    contactNumber: { countryCode: undefined, phoneNumber: undefined },
+    emailAddress: undefined,
+    address: {
+      addressLine1: undefined,
+      addressLine2: undefined,
+      addressLine3: undefined,
+      district: undefined,
+      region: undefined,
+    },
+  })
+
+  const [loading, setLoading] = useState<any>({
+    firstName: true,
+    lastName: true,
+    sex: true,
+    birthDate: true,
+    hkid: true,
+    contactNumber: true,
+    emailAddress: true,
+    address: true,
+  })
+
+  // helper to load latest doc from a subcollection
+  const loadLatest = async (sub: string) => {
+    try {
+      const snap = await getDocs(
+        query(collection(db, 'Students', abbr, sub), orderBy('timestamp', 'desc'), limit(1)),
+      )
+      return snap.empty ? null : snap.docs[0].data()
+    } catch (e) {
+      console.error(`load ${sub} failed`, e)
+      return { __error: true }
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const basicFields = ['firstName', 'lastName', 'sex', 'birthDate']
+      await Promise.all(
+        basicFields.map(async (f) => {
+          try {
+            const data: any = await loadLatest(f)
+            if (cancelled) return
+            const val = data?.__error ? '__ERROR__' : data ? data[f] : undefined
+            setFields((p: any) => ({ ...p, [f]: val }))
+            setLoading((l: any) => {
+              const next = { ...l, [f]: false }
+              console.log('Loading flags now:', next)
+              return next
+            })
+            onPersonal?.({ [f]: val === '__ERROR__' ? undefined : val })
+          } catch (e) {
+            console.error(`basic field ${f} load failed`, e)
+            setFields((p: any) => ({ ...p, [f]: '__ERROR__' }))
+            setLoading((l: any) => {
+              const next = { ...l, [f]: false }
+              console.log('Loading flags now:', next)
+              return next
+            })
+            onPersonal?.({ [f]: undefined })
+          }
+        }),
+      )
+
+      try {
+        const hkidData: any = await loadLatest('HKID')
+        if (!cancelled) {
+          const val = hkidData?.__error ? '__ERROR__' : hkidData?.idNumber
+          setFields((p: any) => ({ ...p, hkid: val }))
+        }
+      } catch (e) {
+        console.error('HKID load failed', e)
+        if (!cancelled) setFields((p: any) => ({ ...p, hkid: '__ERROR__' }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, hkid: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+
+      try {
+        const phoneData: any = await loadLatest('contactNumber')
+        if (!cancelled) {
+          const val = phoneData?.__error
+            ? { countryCode: '__ERROR__', phoneNumber: '__ERROR__' }
+            : {
+                countryCode: phoneData?.countryCode,
+                phoneNumber: phoneData?.phoneNumber,
+              }
+          setFields((p: any) => ({ ...p, contactNumber: val }))
+        }
+      } catch (e) {
+        console.error('contact number load failed', e)
+        if (!cancelled)
+          setFields((p: any) => ({
+            ...p,
+            contactNumber: { countryCode: '__ERROR__', phoneNumber: '__ERROR__' },
+          }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, contactNumber: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+
+      try {
+        const emailData: any = await loadLatest('emailAddress')
+        if (!cancelled) {
+          const val = emailData?.__error ? '__ERROR__' : emailData?.emailAddress
+          setFields((p: any) => ({ ...p, emailAddress: val }))
+        }
+      } catch (e) {
+        console.error('email load failed', e)
+        if (!cancelled) setFields((p: any) => ({ ...p, emailAddress: '__ERROR__' }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, emailAddress: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+
+      try {
+        const addrData: any = await loadLatest('Address')
+        if (!cancelled) {
+          const val = addrData?.__error
+            ? {
+                addressLine1: '__ERROR__',
+                addressLine2: '__ERROR__',
+                addressLine3: '__ERROR__',
+                district: '__ERROR__',
+                region: '__ERROR__',
+              }
+            : {
+                addressLine1: addrData?.addressLine1,
+                addressLine2: addrData?.addressLine2,
+                addressLine3: addrData?.addressLine3,
+                district: addrData?.district,
+                region: addrData?.region,
+              }
+          setFields((p: any) => ({ ...p, address: val }))
+        }
+      } catch (e) {
+        console.error('address load failed', e)
+        if (!cancelled)
+          setFields((p: any) => ({
+            ...p,
+            address: {
+              addressLine1: '__ERROR__',
+              addressLine2: '__ERROR__',
+              addressLine3: '__ERROR__',
+              district: '__ERROR__',
+              region: '__ERROR__',
+            },
+          }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, address: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [abbr, onPersonal])
+
+  const age = (() => {
+    if (!fields.birthDate || fields.birthDate === '__ERROR__') return ''
+    const bd = new Date(fields.birthDate)
+    if (isNaN(bd.getTime())) return ''
+    const diff = Date.now() - bd.getTime()
+    return String(Math.floor(diff / (365.25 * 24 * 60 * 60 * 1000)))
+  })()
+
+  const saveCustom = async (
+    sub: string,
+    prefix: string,
+    data: Record<string, any>,
+    onDone: (d: any) => void,
+  ) => {
+    try {
+      const snap = await getDocs(collection(db, 'Students', abbr, sub))
+      const idx = String(snap.size + 1).padStart(3, '0')
+      const today = new Date()
+      const yyyyMMdd = today.toISOString().slice(0, 10).replace(/-/g, '')
+      const docName = `${abbr}-${prefix}-${idx}-${yyyyMMdd}`
+      await setDoc(doc(db, 'Students', abbr, sub, docName), {
+        ...data,
+        timestamp: today,
+      })
+      onDone(data)
+    } catch (e) {
+      console.error('Save failed', e)
+    }
+  }
+
+  const [editingPhone, setEditingPhone] = useState(false)
+  const [phoneDraft, setPhoneDraft] = useState({ countryCode: '', phoneNumber: '' })
+  const [editingEmail, setEditingEmail] = useState(false)
+  const [emailDraft, setEmailDraft] = useState('')
+  const [editingAddr, setEditingAddr] = useState(false)
+  const [addrDraft, setAddrDraft] = useState({
+    addressLine1: '',
+    addressLine2: '',
+    addressLine3: '',
+    district: '',
+    region: '',
+  })
+  const [editingHKID, setEditingHKID] = useState(false)
+  const [hkidDraft, setHkidDraft] = useState('')
+
+  // handlers for editing start
+  useEffect(() => {
+    if (editingPhone)
+      setPhoneDraft({
+        countryCode:
+          fields.contactNumber.countryCode &&
+          fields.contactNumber.countryCode !== '__ERROR__'
+            ? fields.contactNumber.countryCode
+            : '',
+        phoneNumber:
+          fields.contactNumber.phoneNumber &&
+          fields.contactNumber.phoneNumber !== '__ERROR__'
+            ? fields.contactNumber.phoneNumber
+            : '',
+      })
+    if (editingEmail)
+      setEmailDraft(
+        fields.emailAddress && fields.emailAddress !== '__ERROR__'
+          ? fields.emailAddress
+          : '',
+      )
+    if (editingAddr)
+      setAddrDraft({
+        addressLine1:
+          fields.address.addressLine1 && fields.address.addressLine1 !== '__ERROR__'
+            ? fields.address.addressLine1
+            : '',
+        addressLine2:
+          fields.address.addressLine2 && fields.address.addressLine2 !== '__ERROR__'
+            ? fields.address.addressLine2
+            : '',
+        addressLine3:
+          fields.address.addressLine3 && fields.address.addressLine3 !== '__ERROR__'
+            ? fields.address.addressLine3
+            : '',
+        district:
+          fields.address.district && fields.address.district !== '__ERROR__'
+            ? fields.address.district
+            : '',
+        region:
+          fields.address.region && fields.address.region !== '__ERROR__'
+            ? fields.address.region
+            : '',
+      })
+    if (editingHKID)
+      setHkidDraft(fields.hkid && fields.hkid !== '__ERROR__' ? fields.hkid : '')
+  }, [editingPhone, editingEmail, editingAddr, editingHKID])
+
+  const displayField = (v: any) => {
+    if (v === '__ERROR__') return 'Error'
+    if (v === undefined) return '404 Not Found'
+    if (v === '') return 'N/A'
+    return String(v)
+  }
+
   return (
     <Box>
-      {Object.entries(personal)
-        .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => {
-          const path = `Students/${abbr}/${k}`
-          return (
-            <Box key={k} mb={2}>
-              <Typography variant="subtitle2">{LABELS[k]}</Typography>
-              <InlineEdit
-                value={v}
-                fieldPath={path}
-                fieldKey={k}
-                editable // always editable
-                serviceMode={serviceMode}
-                type={k === 'sex' ? 'select' : k === 'birthDate' ? 'date' : 'text'}
-                options={k === 'sex' ? ['Male', 'Female', 'Other'] : undefined}
-              />
-            </Box>
-          )
-        })}
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Personal Information
+      </Typography>
+      {['firstName', 'lastName'].map((k) => (
+        <Box key={k} mb={2}>
+          <Typography variant="subtitle2">{k === 'firstName' ? 'First Name' : 'Second Name'}</Typography>
+          {loading[k] ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields[k]}
+              fieldPath={`Students/${abbr}/${k}`}
+              fieldKey={k}
+              editable
+              serviceMode={serviceMode}
+              type="text"
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, [k]: v }))
+                onPersonal?.({ [k]: v })
+              }}
+            />
+          )}
+        </Box>
+      ))}
       <Box mb={2}>
-        <Typography variant="subtitle2">Joint Date</Typography>
-        <Typography variant="h6">{jointDate || '–'}</Typography>
+        <Typography variant="subtitle2">Gender</Typography>
+        {loading.sex ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : (
+          <InlineEdit
+            value={fields.sex}
+            fieldPath={`Students/${abbr}/sex`}
+            fieldKey="sex"
+            editable
+            serviceMode={serviceMode}
+            type="select"
+            options={['Male', 'Female', 'Other']}
+            onSaved={(v) => {
+              setFields((p: any) => ({ ...p, sex: v }))
+              onPersonal?.({ sex: v })
+            }}
+          />
+        )}
       </Box>
       <Box mb={2}>
-        <Typography variant="subtitle2">Total Sessions</Typography>
-        <Typography variant="h6">{totalSessions ?? '–'}</Typography>
+        <Typography variant="subtitle2">Age</Typography>
+        <Typography variant="h6">{age || '–'}</Typography>
+      </Box>
+      <Box mb={2}>
+        <Typography variant="subtitle2">Birth Date</Typography>
+        {loading.birthDate ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : (
+          <InlineEdit
+            value={fields.birthDate}
+            fieldPath={`Students/${abbr}/birthDate`}
+            fieldKey="birthDate"
+            editable
+            serviceMode={serviceMode}
+            type="date"
+            onSaved={(v) => {
+              setFields((p: any) => ({ ...p, birthDate: v }))
+              onPersonal?.({ birthDate: v })
+            }}
+          />
+        )}
+      </Box>
+
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        ID no.
+      </Typography>
+      <Box mb={2}>
+        <Typography variant="subtitle2">HKID No.</Typography>
+        {loading.hkid ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingHKID ? (
+          <TextField
+            value={hkidDraft}
+            onChange={(e) => setHkidDraft(e.target.value)}
+            onBlur={() => {
+              if (hkidDraft !== fields.hkid) {
+                saveCustom('HKID', 'hkid', { idNumber: hkidDraft }, () => {
+                  setFields((p: any) => ({ ...p, hkid: hkidDraft }))
+                })
+              }
+              setEditingHKID(false)
+            }}
+            size="small"
+          />
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{ cursor: 'pointer' }}
+            onClick={() => setEditingHKID(true)}
+          >
+            {displayField(fields.hkid)}
+          </Typography>
+        )}
+      </Box>
+
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Contact Information
+      </Typography>
+
+      {/* Contact Number */}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Contact Number</Typography>
+        {loading.contactNumber ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingPhone ? (
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label="Country Code"
+              type="number"
+              value={phoneDraft.countryCode}
+              onChange={(e) => setPhoneDraft((p) => ({ ...p, countryCode: e.target.value }))}
+              size="small"
+            />
+            <TextField
+              label="Phone Number"
+              type="number"
+              value={phoneDraft.phoneNumber}
+              onChange={(e) => setPhoneDraft((p) => ({ ...p, phoneNumber: e.target.value }))}
+              size="small"
+            />
+            <Button
+              onClick={() => {
+                saveCustom(
+                  'contactNumber',
+                  'phone',
+                  {
+                    countryCode: Number(phoneDraft.countryCode) || 0,
+                    phoneNumber: Number(phoneDraft.phoneNumber) || 0,
+                  },
+                  (d) => {
+                    setFields((p: any) => ({ ...p, contactNumber: d }))
+                  },
+                )
+                setEditingPhone(false)
+              }}
+            >
+              Save
+            </Button>
+          </Stack>
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{ cursor: 'pointer' }}
+            onClick={() => setEditingPhone(true)}
+          >
+            {fields.contactNumber.countryCode === undefined &&
+            fields.contactNumber.phoneNumber === undefined
+              ? '404 Not Found'
+              : `+${displayField(fields.contactNumber.countryCode)} ${displayField(
+                  fields.contactNumber.phoneNumber,
+                )}`}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Email Address */}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Email Address</Typography>
+        {loading.emailAddress ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingEmail ? (
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label="Email"
+              value={emailDraft}
+              onChange={(e) => setEmailDraft(e.target.value)}
+              size="small"
+            />
+            <Button
+              onClick={() => {
+                const valid = /.+@.+\..+/.test(emailDraft)
+                if (!valid) {
+                  alert('Invalid email')
+                  return
+                }
+                saveCustom('emailAddress', 'email', { emailAddress: emailDraft }, (d) => {
+                  setFields((p: any) => ({ ...p, emailAddress: d.emailAddress }))
+                })
+                setEditingEmail(false)
+              }}
+            >
+              Save
+            </Button>
+          </Stack>
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{ cursor: 'pointer' }}
+            onClick={() => setEditingEmail(true)}
+          >
+            {displayField(fields.emailAddress)}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Contact Address */}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Contact Address</Typography>
+        {loading.address ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingAddr ? (
+          <Box>
+            <TextField
+              label="Address Line 1"
+              fullWidth
+              value={addrDraft.addressLine1}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, addressLine1: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              label="Address Line 2"
+              fullWidth
+              value={addrDraft.addressLine2}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, addressLine2: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              label="Address Line 3"
+              fullWidth
+              value={addrDraft.addressLine3}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, addressLine3: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              label="District"
+              fullWidth
+              value={addrDraft.district}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, district: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              select
+              label="Region"
+              fullWidth
+              value={addrDraft.region}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, region: e.target.value }))}
+              sx={{ mb: 1 }}
+            >
+              {REGION_OPTIONS.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {r}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Button
+              onClick={() => {
+                saveCustom('Address', 'address', addrDraft, (d) => {
+                  setFields((p: any) => ({ ...p, address: d }))
+                })
+                setEditingAddr(false)
+              }}
+            >
+              Save
+            </Button>
+          </Box>
+        ) : (
+          <Box sx={{ cursor: 'pointer' }} onClick={() => setEditingAddr(true)}>
+            <Typography variant="h6">
+              {displayField(fields.address.addressLine1)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.addressLine2)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.addressLine3)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.district)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.region)}
+            </Typography>
+          </Box>
+        )}
       </Box>
     </Box>
   )
 }
+

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -13,6 +13,8 @@ import InlineEdit from '../../common/InlineEdit'
 import { collection, getDocs, query, orderBy, limit, doc, setDoc } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 
+console.log('=== StudentDialog loaded version 1.1 ===')
+
 // PersonalTab owns all personal information for a student. It fetches the
 // latest values from Firestore and streams key fields upward to OverviewTab via
 // `onPersonal` so OverviewTab can present them without duplicating logic.
@@ -28,6 +30,7 @@ export default function PersonalTab({
   serviceMode: boolean
   onPersonal?: (p: Partial<{ firstName: string; lastName: string; sex: string; birthDate: string }>) => void
 }) {
+  console.log('Rendering PersonalTab for', abbr)
   const [fields, setFields] = useState<any>({
     firstName: undefined,
     lastName: undefined,
@@ -70,6 +73,7 @@ export default function PersonalTab({
   }
 
   useEffect(() => {
+    console.log('PersonalTab effect: load latest fields for', abbr)
     let cancelled = false
     ;(async () => {
       const basicFields = ['firstName', 'lastName', 'sex', 'birthDate']
@@ -256,6 +260,7 @@ export default function PersonalTab({
 
   // handlers for editing start
   useEffect(() => {
+    console.log('PersonalTab effect: populate edit drafts for', abbr)
     if (editingPhone)
       setPhoneDraft({
         countryCode:

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -25,10 +25,12 @@ export default function PersonalTab({
   abbr,
   serviceMode,
   onPersonal,
+  style,
 }: {
   abbr: string
   serviceMode: boolean
   onPersonal?: (p: Partial<{ firstName: string; lastName: string; sex: string; birthDate: string }>) => void
+  style?: React.CSSProperties
 }) {
   console.log('Rendering PersonalTab for', abbr)
   const [fields, setFields] = useState<any>({
@@ -315,7 +317,7 @@ export default function PersonalTab({
   }
 
   return (
-    <Box>
+    <Box style={style} sx={{ textAlign: 'left' }}>
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Personal Information
       </Typography>

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -321,76 +321,95 @@ export default function PersonalTab({
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Personal Information
       </Typography>
-      {['firstName', 'lastName'].map((k) => (
-        <Box key={k} mb={2}>
-          <Typography variant="subtitle2">{k === 'firstName' ? 'First Name' : 'Second Name'}</Typography>
-          {loading[k] ? (
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">First Name</Typography>
+          {loading.firstName ? (
             <Typography variant="h6">Loading…</Typography>
           ) : (
             <InlineEdit
-              value={fields[k]}
-              fieldPath={`Students/${abbr}/${k}`}
-              fieldKey={k}
+              value={fields.firstName}
+              fieldPath={`Students/${abbr}/firstName`}
+              fieldKey="firstName"
               editable
               serviceMode={serviceMode}
               type="text"
               onSaved={(v) => {
-                setFields((p: any) => ({ ...p, [k]: v }))
-                onPersonal?.({ [k]: v })
+                setFields((p: any) => ({ ...p, firstName: v }))
+                onPersonal?.({ firstName: v })
               }}
             />
           )}
         </Box>
-      ))}
-      <Box mb={2}>
-        <Typography variant="subtitle2">Gender</Typography>
-        {loading.sex ? (
-          <Typography variant="h6">Loading…</Typography>
-        ) : (
-          <InlineEdit
-            value={fields.sex}
-            fieldPath={`Students/${abbr}/sex`}
-            fieldKey="sex"
-            editable
-            serviceMode={serviceMode}
-            type="select"
-            options={['Male', 'Female', 'Other']}
-            onSaved={(v) => {
-              setFields((p: any) => ({ ...p, sex: v }))
-              onPersonal?.({ sex: v })
-            }}
-          />
-        )}
-      </Box>
-      <Box mb={2}>
-        <Typography variant="subtitle2">Age</Typography>
-        <Typography variant="h6">{age || '–'}</Typography>
-      </Box>
-      <Box mb={2}>
-        <Typography variant="subtitle2">Birth Date</Typography>
-        {loading.birthDate ? (
-          <Typography variant="h6">Loading…</Typography>
-        ) : (
-          <InlineEdit
-            value={fields.birthDate}
-            fieldPath={`Students/${abbr}/birthDate`}
-            fieldKey="birthDate"
-            editable
-            serviceMode={serviceMode}
-            type="date"
-            onSaved={(v) => {
-              setFields((p: any) => ({ ...p, birthDate: v }))
-              onPersonal?.({ birthDate: v })
-            }}
-          />
-        )}
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Last Name</Typography>
+          {loading.lastName ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.lastName}
+              fieldPath={`Students/${abbr}/lastName`}
+              fieldKey="lastName"
+              editable
+              serviceMode={serviceMode}
+              type="text"
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, lastName: v }))
+                onPersonal?.({ lastName: v })
+              }}
+            />
+          )}
+        </Box>
       </Box>
 
-      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-        ID no.
-      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Gender</Typography>
+          {loading.sex ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.sex}
+              fieldPath={`Students/${abbr}/sex`}
+              fieldKey="sex"
+              editable
+              serviceMode={serviceMode}
+              type="select"
+              options={['Male', 'Female', 'Other']}
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, sex: v }))
+                onPersonal?.({ sex: v })
+              }}
+            />
+          )}
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Age</Typography>
+          <Typography variant="h6">{age || '–'}</Typography>
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Birth Date</Typography>
+          {loading.birthDate ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.birthDate}
+              fieldPath={`Students/${abbr}/birthDate`}
+              fieldKey="birthDate"
+              editable
+              serviceMode={serviceMode}
+              type="date"
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, birthDate: v }))
+                onPersonal?.({ birthDate: v })
+              }}
+            />
+          )}
+        </Box>
+      </Box>
+
       <Box mb={2}>
-        <Typography variant="subtitle2">HKID No.</Typography>
+        <Typography variant="subtitle2">ID No.</Typography>
         {loading.hkid ? (
           <Typography variant="h6">Loading…</Typography>
         ) : editingHKID ? (

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -55,10 +55,12 @@ export default function SessionsTab({
   abbr,
   account,
   onSummary,
+  style,
 }: {
   abbr: string
   account: string
   onSummary?: (s: { jointDate: string; lastSession: string; totalSessions: number }) => void
+  style?: React.CSSProperties
 }) {
   console.log('Rendering SessionsTab for', abbr)
   const [sessions, setSessions] = useState<any[]>([])
@@ -299,7 +301,7 @@ export default function SessionsTab({
     return <CircularProgress />
   }
   return (
-    <>
+    <Box sx={{ textAlign: 'left' }} style={style}>
       <Box mb={2}>
         <Box mb={1}>
           <Typography variant="subtitle2">Joint Date:</Typography>
@@ -428,6 +430,6 @@ export default function SessionsTab({
           <SessionDetail session={popped} onBack={() => setPopped(null)} detached />
         </FloatingWindow>
       )}
-    </>
+    </Box>
   )
 }

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -52,16 +52,10 @@ const toHKTime = (d: Date) => {
 export default function SessionsTab({
   abbr,
   account,
-  jointDate,
-  lastSession,
-  totalSessions,
   onSummary,
 }: {
   abbr: string
   account: string
-  jointDate?: string
-  lastSession?: string
-  totalSessions?: number
   onSummary?: (s: { jointDate: string; lastSession: string; totalSessions: number }) => void
 }) {
   const [sessions, setSessions] = useState<any[]>([])
@@ -82,18 +76,10 @@ export default function SessionsTab({
   const [visibleCols, setVisibleCols] = useState(allColumns.map((c) => c.key))
   const [period, setPeriod] = useState<'30' | '90' | 'all'>('all')
   const [summary, setSummary] = useState({
-    jointDate: jointDate || '',
-    lastSession: lastSession || '',
-    totalSessions: totalSessions ?? 0,
+    jointDate: '',
+    lastSession: '',
+    totalSessions: 0,
   })
-
-  useEffect(() => {
-    setSummary({
-      jointDate: jointDate || '',
-      lastSession: lastSession || '',
-      totalSessions: totalSessions ?? 0,
-    })
-  }, [jointDate, lastSession, totalSessions])
 
   useEffect(() => {
     // SessionsTab owns session summary calculation; OverviewTab consumes the result
@@ -277,13 +263,7 @@ export default function SessionsTab({
         console.log('Computed summary:', newSummary)
 
         const studRef = doc(db, 'Students', abbr)
-        const updates: any = {}
-        if (!jointDate && newSummary.jointDate) updates.jointDate = newSummary.jointDate
-        if (!lastSession && newSummary.lastSession) updates.lastSession = newSummary.lastSession
-        if ((totalSessions == null || totalSessions === 0) && newSummary.totalSessions)
-          updates.totalSessions = newSummary.totalSessions
-        if (Object.keys(updates).length)
-          await setDoc(studRef, updates, { merge: true })
+        await setDoc(studRef, newSummary, { merge: true })
 
         if (!cancelled) {
           setSummary(newSummary)
@@ -294,9 +274,17 @@ export default function SessionsTab({
         console.log('Final session rows:', rows)
       } catch (e) {
         console.error('load sessions failed', e)
-        if (!cancelled) setSessions([])
+        if (!cancelled) {
+          setSessions([])
+          setSummary({ jointDate: '', lastSession: '', totalSessions: 0 })
+          onSummary?.({ jointDate: '', lastSession: '', totalSessions: 0 })
+        }
       } finally {
-        if (!cancelled) setLoading(false)
+        if (!cancelled)
+          setLoading(() => {
+            console.log('Loading flags now: false')
+            return false
+          })
       }
     })()
     return () => {

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -27,6 +27,8 @@ import { db } from '../../lib/firebase'
 import SessionDetail from './SessionDetail'
 import FloatingWindow from './FloatingWindow'
 
+console.log('=== StudentDialog loaded version 1.1 ===')
+
 // SessionsTab is the single source of truth for session data. It fetches
 // appointment history, base rates and payments then streams summary values up
 // to OverviewTab via `onSummary`.
@@ -58,6 +60,7 @@ export default function SessionsTab({
   account: string
   onSummary?: (s: { jointDate: string; lastSession: string; totalSessions: number }) => void
 }) {
+  console.log('Rendering SessionsTab for', abbr)
   const [sessions, setSessions] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [detail, setDetail] = useState<any | null>(null)
@@ -82,6 +85,7 @@ export default function SessionsTab({
   })
 
   useEffect(() => {
+    console.log('SessionsTab effect: load sessions for', abbr)
     // SessionsTab owns session summary calculation; OverviewTab consumes the result
     let cancelled = false
     ;(async () => {


### PR DESCRIPTION
## Summary
- Stop OverviewTab from querying Firestore directly; child tabs now fetch and stream data upward
- Expand PersonalTab with HKID, contact number, email address and full contact address fields
- BillingTab now owns billing calculations and provides Balance Due and Voucher Balance to OverviewTab
- Display `N/A` or `404 Not Found` when student data is missing instead of leaving the dialog stuck
- Always clear loading flags after each fetch in PersonalTab, BillingTab and SessionsTab so the dialog spinner never hangs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e33dcb93c8323bc98688da1f5a968