### PR TITLE
Refactor student dialog data flow and expand personal fields

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,7 @@
 # Agent Guidelines
 
+All field labels must appear on their own line followed by a colon, with the corresponding value rendered on the next line. Field titles use the Newsreader font in Extra Light weight, return strings use Newsreader in Medium weight, and window titles use Cantata One.
+
 Any empty strings or missing data fields retrieved from Firestore should never cause the web app to become unresponsive. Empty string, `null`, or `undefined` values must render as **N/A**, and retrieval failures as **Error**. When a numeric or date value is unavailable simply display a dash (`-`).
 
 Date fields must be validated before calling `.toLocaleDateString()` or similar methods. Invalid or empty values should be ignored, and the UI should show a placeholder rather than throwing errors or becoming stuck.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,6 +1,6 @@
 # Agent Guidelines
 
-Any empty strings or missing data fields retrieved from Firestore should never cause the web app to become unresponsive. Empty string values must render as **N/A**, missing values as **404/Not Found**, and retrieval failures as **Error**. When a numeric or date value is unavailable simply display a dash (`-`).
+Any empty strings or missing data fields retrieved from Firestore should never cause the web app to become unresponsive. Empty string, `null`, or `undefined` values must render as **N/A**, and retrieval failures as **Error**. When a numeric or date value is unavailable simply display a dash (`-`).
 
 Date fields must be validated before calling `.toLocaleDateString()` or similar methods. Invalid or empty values should be ignored, and the UI should show a placeholder rather than throwing errors or becoming stuck.
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -15,3 +15,5 @@ Another hang arose when the initial spinner replaced the entire tab layout. With
 Continuous reloads later surfaced when `OverviewTab` passed inline callbacks to the child tabs. Each render created new `onPersonal`, `onBilling`, and `onSummary` functions, triggering the children’s `useEffect` hooks repeatedly and re-fetching data in a loop. Memoizing these handlers with `useCallback` stabilised their references and stopped the dialog from constantly refreshing.
 
 The most recent reload loop traced to defining the error boundary inside `OverviewTab`. Because the boundary class was re-created on every render, React unmounted and remounted the entire dialog tree, resetting all loading flags and re-triggering data fetches. Moving the boundary to the module scope keeps its identity stable and prevents the dialog from restarting after each render.
+
+Floating windows later became immovable when a `onMouseDown` handler on the header stopped drag events from reaching `react-rnd`. Removing that handler restored independent window movement.

--- a/README.md
+++ b/README.md
@@ -53,4 +53,8 @@ Field numbers are:
 
 Each document stores only the edited value and a `timestamp` so the full history
 can be tracked.
+
+## Placeholder Display
+
+When values are not available from Firestore the UI must remain responsive and show placeholders instead of failing. Empty strings render as **N/A**, missing values as **404 Not Found** and retrieval errors as **Error**. Numeric or date values that are unavailable should display a dash (`-`).
  

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ can be tracked.
 
 ## Placeholder Display
 
-When values are not available from Firestore the UI must remain responsive and show placeholders instead of failing. Empty strings render as **N/A**, missing values as **404 Not Found** and retrieval errors as **Error**. Numeric or date values that are unavailable should display a dash (`-`).
+When values are not available from Firestore the UI must remain responsive and show placeholders instead of failing. Empty strings, `null`, or `undefined` values render as **N/A**, while retrieval errors display as **Error**. Numeric or date values that are unavailable should show a dash (`-`).
  

--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -97,8 +97,7 @@ export default function InlineEdit({
 
   const display = () => {
     if (draft === '__ERROR__') return 'Error'
-    if (draft === undefined) return '404 Not Found'
-    if (draft === '' || draft === null)
+    if (draft === undefined || draft === null || draft === '')
       return type === 'number' || type === 'date' ? '-' : 'N/A'
     if (type === 'date') {
       const d = new Date(draft)

--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -111,7 +111,7 @@ export default function InlineEdit({
     return (
       <Typography
         variant="h6"
-        sx={{ cursor: 'pointer' }}
+        sx={{ cursor: 'pointer', fontFamily: 'Newsreader', fontWeight: 500 }}
         onClick={showHistory}
       >
         {display()}
@@ -120,7 +120,11 @@ export default function InlineEdit({
   }
 
   if (!allowEdit) {
-    return <Typography variant="h6">{display()}</Typography>
+    return (
+      <Typography variant="h6" sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+        {display()}
+      </Typography>
+    )
   }
 
   return editing ? (
@@ -168,8 +172,10 @@ export default function InlineEdit({
   ) : (
     <Typography
       variant="h6"
-      sx={{ cursor: 'pointer' }}
-      onClick={() => { if (allowEdit) setEditing(true) }}
+      sx={{ cursor: 'pointer', fontFamily: 'Newsreader', fontWeight: 500 }}
+      onClick={() => {
+        if (allowEdit) setEditing(true)
+      }}
     >
       {display() || '[click to edit]'}
     </Typography>

--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -13,6 +13,7 @@ export interface InlineEditProps {
   serviceMode?: boolean
   type: 'text' | 'number' | 'date' | 'select'
   options?: string[]
+  onSaved?: (v: any) => void
 }
 
 export default function InlineEdit({
@@ -23,6 +24,7 @@ export default function InlineEdit({
   serviceMode = false,
   type,
   options,
+  onSaved,
 }: InlineEditProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value)
@@ -67,6 +69,7 @@ export default function InlineEdit({
         timestamp: today,
       })
       setDraft(v)
+      onSaved?.(v)
     } catch (e) {
       console.error('Save failed', e)
     }
@@ -93,8 +96,15 @@ export default function InlineEdit({
   }
 
   const display = () => {
-    if (type === 'date' && draft) return new Date(draft).toLocaleDateString()
-    return String(draft ?? '')
+    if (draft === '__ERROR__') return 'Error'
+    if (draft === undefined) return '404 Not Found'
+    if (draft === '' || draft === null)
+      return type === 'number' || type === 'date' ? '-' : 'N/A'
+    if (type === 'date') {
+      const d = new Date(draft)
+      return isNaN(d.getTime()) ? '-' : d.toLocaleDateString()
+    }
+    return String(draft)
   }
 
   // when Service Mode is ON, disable edits and clicking shows full audit trail

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -247,20 +247,43 @@ export default function BillingTab({
         : `Students/${abbr}/${k}`
     return (
       <Box key={k} mb={2}>
-        <Typography variant="subtitle2">{LABELS[k]}</Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          {LABELS[k]}:
+        </Typography>
         {loading[k] ? (
-          <Typography variant="h6">Loading…</Typography>
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            Loading…
+          </Typography>
         ) : k === 'baseRate' ? (
-          <Typography variant="h6">
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
             {v != null && !isNaN(Number(v)) ? `${formatCurrency(Number(v))} / session` : '-'}
           </Typography>
         ) : ['balanceDue', 'voucherBalance'].includes(k) ? (
-          <Typography variant="h6">
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
             {v != null && !isNaN(Number(v)) ? formatCurrency(Number(v)) : '-'}
           </Typography>
         ) : k === 'lastPaymentDate' ? (
-          <Typography variant="h6">
-            {v ? (v.toDate ? v.toDate().toLocaleDateString() : new Date(v).toLocaleDateString()) : '-'}
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            {v
+              ? v.toDate
+                ? v.toDate().toLocaleDateString()
+                : new Date(v).toLocaleDateString()
+              : '-'}
           </Typography>
         ) : (
           <InlineEdit

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -255,7 +255,7 @@ export default function BillingTab({
   }
 
   return (
-    <Box style={style} sx={{ textAlign: 'left' }}>
+    <Box style={style} sx={{ textAlign: 'left', maxWidth: '100%', maxHeight: '100%', overflow: 'auto' }}>
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Billing Information
       </Typography>

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -1,15 +1,15 @@
 // components/StudentDialog/BillingTab.tsx
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Typography } from '@mui/material'
-import { collection, getDocs, query, where, orderBy } from 'firebase/firestore'
+import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
+import InlineEdit from '../../common/InlineEdit'
+
+console.log('=== StudentDialog loaded version 1.1 ===')
 
 const formatCurrency = (n: number) =>
-  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(
-    n,
-  )
-import InlineEdit from '../../common/InlineEdit'
+  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
 
 const LABELS: Record<string, string> = {
   billingCompany: 'Billing Company Info',
@@ -21,21 +21,95 @@ const LABELS: Record<string, string> = {
   voucherBalance: 'Voucher Balance',
 }
 
+// BillingTab owns all billing-related fetching and calculations. It streams
+// summary values (Balance Due, Voucher Balance) up to OverviewTab via
+// `onBilling`.
+
 export default function BillingTab({
   abbr,
   account,
-  billing,
   serviceMode,
-  onBalanceDue,
+  onBilling,
+  style,
 }: {
   abbr: string
   account: string
-  billing: any
   serviceMode: boolean
-  onBalanceDue?: (n: number) => void
+  onBilling?: (b: Partial<{ balanceDue: number; voucherBalance: number }>) => void
+  style?: React.CSSProperties
 }) {
+  console.log('Rendering BillingTab for', abbr)
+  const [fields, setFields] = useState<any>({})
+  const [loading, setLoading] = useState<any>({
+    billingCompany: true,
+    defaultBillingType: true,
+    baseRate: true,
+    retainerStatus: true,
+    lastPaymentDate: true,
+    balanceDue: true,
+    voucherBalance: true,
+  })
+
+  const loadLatest = async (sub: string, field: string) => {
+    try {
+      const snap = await getDocs(
+        query(collection(db, 'Students', abbr, sub), orderBy('timestamp', 'desc'), limit(1)),
+      )
+      return snap.empty ? undefined : (snap.docs[0].data() as any)[field]
+    } catch (e) {
+      console.error(`load ${sub} failed`, e)
+      return '__ERROR__'
+    }
+  }
+
   useEffect(() => {
-    // BillingTab owns Balance Due calculation; OverviewTab consumes the result
+    console.log('BillingTab effect: load simple fields for', abbr)
+    let cancelled = false
+    ;(async () => {
+      const simple = [
+        'billingCompany',
+        'defaultBillingType',
+        'baseRate',
+        'retainerStatus',
+        'lastPaymentDate',
+        'voucherBalance',
+      ]
+      for (const f of simple) {
+        try {
+          const val: any = await loadLatest(
+            f === 'defaultBillingType' ? 'billingType' : f,
+            f === 'baseRate' ? 'rate' : f,
+          )
+          if (cancelled) return
+          setFields((b: any) => ({ ...b, [f]: val }))
+          setLoading((l: any) => {
+            const next = { ...l, [f]: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          if (f === 'voucherBalance')
+            onBilling?.({ voucherBalance: typeof val === 'number' ? val : undefined })
+        } catch (e) {
+          console.error(`${f} load failed`, e)
+          if (cancelled) return
+          setFields((b: any) => ({ ...b, [f]: '__ERROR__' }))
+          setLoading((l: any) => {
+            const next = { ...l, [f]: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          if (f === 'voucherBalance') onBilling?.({ voucherBalance: undefined })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [abbr, onBilling])
+
+  useEffect(() => {
+    console.log('BillingTab effect: calculate balance due for', abbr)
+    // Balance Due calculation
     let cancelled = false
     ;(async () => {
       try {
@@ -56,12 +130,7 @@ export default function BillingTab({
 
         const [baseRateSnap, paymentSnap, sessionRows] = await Promise.all([
           getDocs(collection(db, 'Students', abbr, 'BaseRateHistory')),
-          getDocs(
-            query(
-              collection(db, 'Students', abbr, 'Payments'),
-              orderBy('paymentMade'),
-            ),
-          ),
+          getDocs(query(collection(db, 'Students', abbr, 'Payments'), orderBy('paymentMade'))),
           Promise.all(rowPromises),
         ])
 
@@ -87,10 +156,8 @@ export default function BillingTab({
           const hist = history
             .slice()
             .sort((a: any, b: any) => {
-              const ta =
-                parseDate(a.changeTimestamp) || parseDate(a.timestamp) || new Date(0)
-              const tb =
-                parseDate(b.changeTimestamp) || parseDate(b.timestamp) || new Date(0)
+              const ta = parseDate(a.changeTimestamp) || parseDate(a.timestamp) || new Date(0)
+              const tb = parseDate(b.changeTimestamp) || parseDate(b.timestamp) || new Date(0)
               return tb.getTime() - ta.getTime()
             })[0]
           if (!hist) {
@@ -106,9 +173,7 @@ export default function BillingTab({
           }
           const base = (() => {
             if (!baseRates.length) return '-'
-            const entry = baseRates
-              .filter((b) => b.ts.getTime() <= startDate.getTime())
-              .pop()
+            const entry = baseRates.filter((b) => b.ts.getTime() <= startDate.getTime()).pop()
             return entry ? entry.rate : '-'
           })()
           const rateHist = rateDocs
@@ -120,8 +185,7 @@ export default function BillingTab({
             })
           const latestRate = rateHist[0]?.rateCharged
           const rateCharged = latestRate != null ? Number(latestRate) : base
-          if (rateCharged != null && !isNaN(Number(rateCharged)))
-            totalOwed += Number(rateCharged)
+          if (rateCharged != null && !isNaN(Number(rateCharged))) totalOwed += Number(rateCharged)
         })
 
         const totalPaid = paymentSnap.docs.reduce((sum, d) => {
@@ -130,18 +194,35 @@ export default function BillingTab({
         }, 0)
 
         const balanceDue = totalOwed - totalPaid
-        if (!cancelled) onBalanceDue?.(balanceDue)
+        if (!cancelled) {
+          setFields((b: any) => ({ ...b, balanceDue }))
+          setLoading((l: any) => {
+            const next = { ...l, balanceDue: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          onBilling?.({ balanceDue })
+        }
       } catch (e) {
         console.error('balance due calculation failed', e)
-        if (!cancelled) onBalanceDue?.(0)
+        if (!cancelled) {
+          setFields((b: any) => ({ ...b, balanceDue: 0 }))
+          setLoading((l: any) => {
+            const next = { ...l, balanceDue: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+          onBilling?.({ balanceDue: 0 })
+        }
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [abbr, account, onBalanceDue])
+  }, [abbr, account, onBilling])
+
   const renderField = (k: string) => {
-    const v = billing[k]
+    const v = fields[k]
     const path =
       k === 'defaultBillingType'
         ? `Students/${abbr}/billingType`
@@ -149,11 +230,11 @@ export default function BillingTab({
     return (
       <Box key={k} mb={2}>
         <Typography variant="subtitle2">{LABELS[k]}</Typography>
-        {k === 'baseRate' ? (
+        {loading[k] ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : k === 'baseRate' ? (
           <Typography variant="h6">
-            {v != null && !isNaN(Number(v))
-              ? `${formatCurrency(Number(v))} / session`
-              : '-'}
+            {v != null && !isNaN(Number(v)) ? `${formatCurrency(Number(v))} / session` : '-'}
           </Typography>
         ) : (
           <InlineEdit
@@ -163,6 +244,10 @@ export default function BillingTab({
             editable={!['balanceDue', 'voucherBalance'].includes(k)}
             serviceMode={serviceMode}
             type={k.includes('Date') ? 'date' : 'text'}
+            onSaved={(val) => {
+              setFields((b: any) => ({ ...b, [k]: val }))
+              if (k === 'voucherBalance') onBilling?.({ voucherBalance: Number(val) })
+            }}
           />
         )}
       </Box>
@@ -170,15 +255,18 @@ export default function BillingTab({
   }
 
   return (
-    <Box>
+    <Box style={style} sx={{ textAlign: 'left' }}>
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Billing Information
       </Typography>
-      {['balanceDue', 'baseRate', 'retainerStatus', 'lastPaymentDate', 'voucherBalance'].map(renderField)}
+      {['balanceDue', 'baseRate', 'retainerStatus', 'lastPaymentDate', 'voucherBalance'].map(
+        (k) => renderField(k),
+      )}
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
         Payment Information
       </Typography>
-      {['defaultBillingType', 'billingCompany'].map(renderField)}
+      {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
     </Box>
   )
 }
+

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -23,21 +23,17 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
           bottom: 0,
           bgcolor: 'background.paper',
           zIndex: 1500,
-          p: 1,
-          maxHeight: '100%',
-          maxWidth: '100%',
-          overflow: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
-        <IconButton onClick={onClose} sx={{ float: 'right' }} aria-label="close window">
-          <CloseIcon />
-        </IconButton>
-        {title && (
-          <Typography variant="h6" sx={{ mb: 1 }}>
-            {title}
-          </Typography>
-        )}
-        {children}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
+          {title && <Typography variant="h6">{title}</Typography>}
+          <IconButton onClick={onClose} aria-label="close window">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
       </Box>
     )
   }
@@ -52,27 +48,30 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
     >
       <Box
         sx={{
-          p: 1,
           bgcolor: 'background.paper',
           height: '100%',
           width: '100%',
           boxShadow: 3,
-          maxHeight: '100%',
-          maxWidth: '100%',
-          overflow: 'auto',
           display: 'flex',
           flexDirection: 'column',
         }}
       >
-        <IconButton onClick={onClose} sx={{ float: 'right' }} aria-label="close window">
-          <CloseIcon />
-        </IconButton>
-        {title && (
-          <Typography variant="h6" sx={{ mb: 1 }}>
-            {title}
-          </Typography>
-        )}
-        {children}
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            p: 1,
+            borderBottom: 1,
+            borderColor: 'divider',
+          }}
+        >
+          {title && <Typography variant="h6">{title}</Typography>}
+          <IconButton onClick={onClose} aria-label="close window">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
       </Box>
     </Rnd>
   )

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -34,7 +34,11 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
           }}
         >
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
-            {title && <Typography variant="h6">{title}</Typography>}
+            {title && (
+              <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
+                {title}
+              </Typography>
+            )}
             <Box>
               {actions}
               <IconButton onClick={onClose} aria-label="close window">
@@ -79,7 +83,11 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               cursor: 'move',
             }}
           >
-            {title && <Typography variant="h6">{title}</Typography>}
+            {title && (
+              <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
+                {title}
+              </Typography>
+            )}
             <Box>
               {actions}
               <IconButton onClick={onClose} aria-label="close window">

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -69,7 +69,6 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
         >
           <Box
             className={HANDLE_CLASS}
-            onMouseDown={(e) => e.stopPropagation()}
             sx={{
               display: 'flex',
               justifyContent: 'space-between',

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Rnd } from 'react-rnd'
-import { Box, IconButton } from '@mui/material'
+import { Box, IconButton, Typography } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 
 interface FloatingWindowProps {
@@ -29,6 +29,11 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
         <IconButton onClick={onClose} sx={{ float: 'right' }} aria-label="close window">
           <CloseIcon />
         </IconButton>
+        {title && (
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            {title}
+          </Typography>
+        )}
         {children}
       </Box>
     )
@@ -45,6 +50,11 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
         <IconButton onClick={onClose} sx={{ float: 'right' }} aria-label="close window">
           <CloseIcon />
         </IconButton>
+        {title && (
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            {title}
+          </Typography>
+        )}
         {children}
       </Box>
     </Rnd>

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { Rnd } from 'react-rnd'
 import { Box, IconButton, Typography } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
@@ -12,67 +13,75 @@ interface FloatingWindowProps {
 // FloatingWindow renders detachable content using react-rnd. On small screens
 // (<600px) it falls back to a full-screen overlay without drag/resize.
 export default function FloatingWindow({ title, children, onClose }: FloatingWindowProps) {
-  if (typeof window !== 'undefined' && window.innerWidth < 600) {
-    return (
-      <Box
-        sx={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          bgcolor: 'background.paper',
-          zIndex: 1500,
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
-          {title && <Typography variant="h6">{title}</Typography>}
-          <IconButton onClick={onClose} aria-label="close window">
-            <CloseIcon />
-          </IconButton>
-        </Box>
-        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
-      </Box>
-    )
-  }
+  const body =
+    typeof document !== 'undefined' ? document.body : undefined
 
-  return (
-    <Rnd
-      default={{ x: 80, y: 80, width: 900, height: 600 }}
-      minWidth={300}
-      minHeight={200}
-      bounds="window"
-      style={{ zIndex: 1500 }}
-    >
-      <Box
-        sx={{
-          bgcolor: 'background.paper',
-          height: '100%',
-          width: '100%',
-          boxShadow: 3,
-          display: 'flex',
-          flexDirection: 'column',
-        }}
+  const content = () => {
+    if (typeof window !== 'undefined' && window.innerWidth < 600) {
+      return (
+        <Box
+          sx={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            bgcolor: 'background.paper',
+            zIndex: 1500,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
+            {title && <Typography variant="h6">{title}</Typography>}
+            <IconButton onClick={onClose} aria-label="close window">
+              <CloseIcon />
+            </IconButton>
+          </Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
+        </Box>
+      )
+    }
+
+    return (
+      <Rnd
+        default={{ x: 80, y: 80, width: 900, height: 600 }}
+        minWidth={300}
+        minHeight={200}
+        bounds="window"
+        style={{ zIndex: 1500 }}
       >
         <Box
           sx={{
+            bgcolor: 'background.paper',
+            height: '100%',
+            width: '100%',
+            boxShadow: 3,
             display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            p: 1,
-            borderBottom: 1,
-            borderColor: 'divider',
+            flexDirection: 'column',
           }}
         >
-          {title && <Typography variant="h6">{title}</Typography>}
-          <IconButton onClick={onClose} aria-label="close window">
-            <CloseIcon />
-          </IconButton>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              p: 1,
+              borderBottom: 1,
+              borderColor: 'divider',
+            }}
+          >
+            {title && <Typography variant="h6">{title}</Typography>}
+            <IconButton onClick={onClose} aria-label="close window">
+              <CloseIcon />
+            </IconButton>
+          </Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
         </Box>
-        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
-      </Box>
-    </Rnd>
-  )
+      </Rnd>
+    )
+  }
+
+  const node = content()
+  return body ? createPortal(node, body) : node
 }

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -47,13 +47,15 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
       )
     }
 
+    const HANDLE_CLASS = 'floating-window-handle'
     return (
       <Rnd
-        default={{ x: 80, y: 80, width: 900, height: 600 }}
+        default={{ x: 120, y: 80, width: 900, height: 600 }}
         minWidth={300}
         minHeight={200}
         bounds="window"
         style={{ zIndex: 1500 }}
+        dragHandleClassName={HANDLE_CLASS}
       >
         <Box
           sx={{
@@ -66,6 +68,8 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
           }}
         >
           <Box
+            className={HANDLE_CLASS}
+            onMouseDown={(e) => e.stopPropagation()}
             sx={{
               display: 'flex',
               justifyContent: 'space-between',
@@ -73,6 +77,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               p: 1,
               borderBottom: 1,
               borderColor: 'divider',
+              cursor: 'move',
             }}
           >
             {title && <Typography variant="h6">{title}</Typography>}

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -22,8 +22,11 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
           right: 0,
           bottom: 0,
           bgcolor: 'background.paper',
-          zIndex: 1300,
+          zIndex: 1500,
           p: 1,
+          maxHeight: '100%',
+          maxWidth: '100%',
+          overflow: 'auto',
         }}
       >
         <IconButton onClick={onClose} sx={{ float: 'right' }} aria-label="close window">
@@ -41,12 +44,26 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
 
   return (
     <Rnd
-      default={{ x: 80, y: 80, width: 400, height: 300 }}
+      default={{ x: 80, y: 80, width: 900, height: 600 }}
       minWidth={300}
       minHeight={200}
       bounds="window"
+      style={{ zIndex: 1500 }}
     >
-      <Box sx={{ p: 1, bgcolor: 'background.paper', height: '100%', boxShadow: 3 }}>
+      <Box
+        sx={{
+          p: 1,
+          bgcolor: 'background.paper',
+          height: '100%',
+          width: '100%',
+          boxShadow: 3,
+          maxHeight: '100%',
+          maxWidth: '100%',
+          overflow: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
         <IconButton onClick={onClose} sx={{ float: 'right' }} aria-label="close window">
           <CloseIcon />
         </IconButton>

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -8,11 +8,12 @@ interface FloatingWindowProps {
   title?: string
   children: React.ReactNode
   onClose: () => void
+  actions?: React.ReactNode | null
 }
 
 // FloatingWindow renders detachable content using react-rnd. On small screens
 // (<600px) it falls back to a full-screen overlay without drag/resize.
-export default function FloatingWindow({ title, children, onClose }: FloatingWindowProps) {
+export default function FloatingWindow({ title, children, onClose, actions }: FloatingWindowProps) {
   const body =
     typeof document !== 'undefined' ? document.body : undefined
 
@@ -34,9 +35,12 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
         >
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
             {title && <Typography variant="h6">{title}</Typography>}
-            <IconButton onClick={onClose} aria-label="close window">
-              <CloseIcon />
-            </IconButton>
+            <Box>
+              {actions}
+              <IconButton onClick={onClose} aria-label="close window">
+                <CloseIcon />
+              </IconButton>
+            </Box>
           </Box>
           <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
         </Box>
@@ -72,9 +76,12 @@ export default function FloatingWindow({ title, children, onClose }: FloatingWin
             }}
           >
             {title && <Typography variant="h6">{title}</Typography>}
-            <IconButton onClick={onClose} aria-label="close window">
-              <CloseIcon />
-            </IconButton>
+            <Box>
+              {actions}
+              <IconButton onClick={onClose} aria-label="close window">
+                <CloseIcon />
+              </IconButton>
+            </Box>
           </Box>
           <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
         </Box>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -179,13 +179,19 @@ export default function OverviewTab({
               }}
             >
               <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
-                <Typography variant="subtitle2">
-                  Legal Name{' '}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+                >
+                  Legal Name:{' '}
                   {(personalLoading.firstName || personalLoading.lastName) && (
                     <CircularProgress size={14} />
                   )}
                 </Typography>
-                <Typography variant="h6">
+                <Typography
+                  variant="h6"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                >
                   {(personalLoading.firstName || personalLoading.lastName)
                     ? 'Loading…'
                     : (() => {
@@ -196,54 +202,112 @@ export default function OverviewTab({
                       })()}
                 </Typography>
 
-                <Typography variant="subtitle2">
-                  Gender {personalLoading.sex && <CircularProgress size={14} />}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+                >
+                  Gender:{' '}
+                  {personalLoading.sex && <CircularProgress size={14} />}
                 </Typography>
-                <Typography variant="h6">
+                <Typography
+                  variant="h6"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                >
                   {personalLoading.sex
                     ? 'Loading…'
                     : displayField(personal.sex)}
                 </Typography>
 
-                <Typography variant="subtitle2">
-                  Joint Date {overviewLoading && <CircularProgress size={14} />}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+                >
+                  Joint Date:{' '}
+                  {overviewLoading && <CircularProgress size={14} />}
                 </Typography>
                 {overviewLoading ? (
-                  <Typography variant="h6">Loading…</Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
+                    Loading…
+                  </Typography>
                 ) : (
-                  <Typography variant="h6">{overview.joint || '–'}</Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
+                    {overview.joint || '–'}
+                  </Typography>
                 )}
 
-                <Typography variant="subtitle2">
-                  Total Sessions {overviewLoading && <CircularProgress size={14} />}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+                >
+                  Total Sessions:{' '}
+                  {overviewLoading && <CircularProgress size={14} />}
                 </Typography>
                 {overviewLoading ? (
-                  <Typography variant="h6">Loading…</Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
+                    Loading…
+                  </Typography>
                 ) : (
-                  <Typography variant="h6">{overview.total ?? '–'}</Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
+                    {overview.total ?? '–'}
+                  </Typography>
                 )}
 
-                <Typography variant="subtitle2">
-                  Balance Due {billingLoading.balanceDue && <CircularProgress size={14} />}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+                >
+                  Balance Due:{' '}
+                  {billingLoading.balanceDue && <CircularProgress size={14} />}
                 </Typography>
                 {billingLoading.balanceDue ? (
-                  <Typography variant="h6">Loading…</Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
+                    Loading…
+                  </Typography>
                 ) : (
-                  <Typography variant="h6">
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
                     {billing.balanceDue != null
                       ? formatCurrency(Number(billing.balanceDue) || 0)
                       : '-'}
                   </Typography>
                 )}
 
-                <Typography variant="subtitle2">
-                  Session Voucher{' '}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+                >
+                  Session Voucher:{' '}
                   {billingLoading.voucherBalance && <CircularProgress size={14} />}
                 </Typography>
                 {billingLoading.voucherBalance ? (
-                  <Typography variant="h6">Loading…</Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
+                    Loading…
+                  </Typography>
                 ) : (
-                  <Typography variant="h6">
+                  <Typography
+                    variant="h6"
+                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  >
                     {billing.voucherBalance != null
                       ? formatCurrency(Number(billing.voucherBalance) || 0)
                       : '-'}

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -354,7 +354,16 @@ export default function OverviewTab({
               }}
             >
               {['Overview', 'Personal', 'Sessions', 'Billing'].map((l) => (
-                <Tab key={l} label={l} sx={{ textAlign: 'right' }} />
+                <Tab
+                  key={l}
+                  label={l}
+                  sx={{
+                    textAlign: 'right',
+                    justifyContent: 'flex-end',
+                    alignItems: 'flex-end',
+                    width: '100%',
+                  }}
+                />
               ))}
             </Tabs>
           </Box>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -255,6 +255,7 @@ export default function OverviewTab({
                 account={account}
                 onSummary={handleSummary}
                 onTitle={setTitle}
+                onClose={onClose}
                 style={{ display: tab === 2 ? 'block' : 'none' }}
               />
 

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -1,36 +1,42 @@
 // components/StudentDialog/OverviewTab.tsx
 
-import React, { useEffect, useState } from 'react'
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Tabs,
-  Tab,
-  Box,
-  CircularProgress,
-  Typography,
-  Button,
-} from '@mui/material'
-import {
-  collection,
-  getDocs,
-  getDoc,
-  doc,
-  query,
-  orderBy,
-  limit,
-} from 'firebase/firestore'
-import { db } from '../../lib/firebase'
+import React, { useEffect, useState, useCallback } from 'react'
+import { Tabs, Tab, Box, CircularProgress, Typography, Button } from '@mui/material'
+import FloatingWindow from './FloatingWindow'
 
-// OverviewTab displays summary values supplied by child tabs (PersonalTab,
-// SessionsTab, BillingTab). These children own their respective data fetching
-// and push updates here via callbacks, keeping OverviewTab as a pure presenter.
-import InlineEdit from '../../common/InlineEdit'
+// OverviewTab acts purely as a presenter. PersonalTab, SessionsTab and
+// BillingTab each fetch and compute their own data then "stream" summary
+// values upward via callbacks. OverviewTab never queries Firestore directly,
+// keeping a single source of truth in the owning tab and avoiding duplicated
+// logic across the dialog.
 import PersonalTab from './PersonalTab'
 import BillingTab from './BillingTab'
 import SessionsTab from './SessionsTab'
+
+console.log('=== StudentDialog loaded version 1.1 ===')
+
+class StudentDialogErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null }
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('StudentDialog render error', error, info)
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <Box p={2}>
+          <Typography color="error">Student dialog failed to load.</Typography>
+        </Box>
+      )
+    }
+    return this.props.children
+  }
+}
 
 export interface OverviewTabProps {
   abbr: string
@@ -47,144 +53,121 @@ export default function OverviewTab({
   onClose,
   serviceMode,
 }: OverviewTabProps) {
-  const [loading, setLoading] = useState(true)
+  console.log('OverviewTab rendered for', abbr)
   const [tab, setTab] = useState(0)
+  const [title, setTitle] = useState(account)
 
-  // personal
+  // personal summary streamed from PersonalTab
   const [personal, setPersonal] = useState<any>({})
   const [personalLoading, setPersonalLoading] = useState({
     firstName: true,
     lastName: true,
     sex: true,
-    birthDate: true,
   })
 
-  // billing
+  // billing summary streamed from BillingTab
   const [billing, setBilling] = useState<any>({})
   const [billingLoading, setBillingLoading] = useState({
-    billingCompany: true,
-    defaultBillingType: true,
-    baseRate: true,
-    retainerStatus: true,
-    lastPaymentDate: true,
     balanceDue: true,
     voucherBalance: true,
   })
 
-  // overview + sessions
+  // overview summary streamed from SessionsTab
   const [overview, setOverview] = useState<any>({ joint: '', last: '', total: 0 })
   const [overviewLoading, setOverviewLoading] = useState(true)
 
-  const handleBalanceDue = (n: number) => {
-    setBilling((b: any) => ({ ...b, balanceDue: n }))
-    setBillingLoading((l) => ({ ...l, balanceDue: false }))
-  }
+  const handlePersonal = useCallback(
+    (data: Partial<{ firstName: string; lastName: string; sex: string }>) => {
+      setPersonal((p: any) => ({ ...p, ...data }))
+      Object.keys(data).forEach((k) =>
+        setPersonalLoading((l: any) => ({ ...l, [k]: false }))
+      )
+    },
+    [setPersonal, setPersonalLoading],
+  )
 
-  const handleSummary = (s: {
-    jointDate: string
-    lastSession: string
-    totalSessions: number
-  }) => {
-    setOverview({ joint: s.jointDate, last: s.lastSession, total: s.totalSessions })
-  }
+  const handleBilling = useCallback(
+    (data: Partial<{ balanceDue: number; voucherBalance: number }>) => {
+      setBilling((b: any) => ({ ...b, ...data }))
+      Object.keys(data).forEach((k) =>
+        setBillingLoading((l: any) => ({ ...l, [k]: false }))
+      )
+    },
+    [setBilling, setBillingLoading],
+  )
+
+  const handleSummary = useCallback(
+    (s: { jointDate: string; lastSession: string; totalSessions: number }) => {
+      setOverview({ joint: s.jointDate, last: s.lastSession, total: s.totalSessions })
+      setOverviewLoading(false)
+    },
+    [setOverview, setOverviewLoading],
+  )
+
+  // reset loading states whenever dialog is opened
+  useEffect(() => {
+    console.log('OverviewTab reset effect for', abbr)
+    if (open) {
+      setPersonal({})
+      setBilling({})
+      setOverview({ joint: '', last: '', total: 0 })
+      setPersonalLoading({ firstName: true, lastName: true, sex: true })
+      setBillingLoading({ balanceDue: true, voucherBalance: true })
+      setOverviewLoading(true)
+      setTab(0)
+      setTitle(account)
+    }
+  }, [open])
 
   useEffect(() => {
-    if (!open) return
-    let mounted = true
-
-    const loadLatest = async (col: string) => {
-      let collectionName = col
-      let field = col
-      if (col === 'baseRate') {
-        collectionName = 'BaseRateHistory'
-        field = 'rate'
-      }
-      if (col === 'defaultBillingType') {
-        collectionName = 'billingType'
-        field = 'billingType'
-      }
-      const snap = await getDocs(
-        query(
-          collection(db, 'Students', abbr, collectionName),
-          orderBy('timestamp', 'desc'),
-          limit(1)
-        )
-      )
-      if (snap.empty) {
-        console.warn(`⚠️ no ${col} for ${abbr}`)
-        return ''
-      }
-      const val = (snap.docs[0].data() as any)[field]
-      return val
-    }
-
-    // load personal fields
-    ;['firstName', 'lastName', 'sex', 'birthDate'].forEach((f) => {
-      loadLatest(f).then((v) => {
-        if (!mounted) return
-        setPersonal((p: any) => ({ ...p, [f]: v }))
-        setPersonalLoading((l) => ({ ...l, [f]: false }))
-      })
+    console.log('OverviewTab loading states', {
+      personalLoading,
+      billingLoading,
+      overviewLoading,
     })
+  })
 
-    // load billing fields
-    ;[
-      'billingCompany',
-      'defaultBillingType',
-      'baseRate',
-      'retainerStatus',
-      'lastPaymentDate',
-      'voucherBalance',
-    ].forEach((f) => {
-      loadLatest(f).then((v) => {
-        if (!mounted) return
-        setBilling((b: any) => ({ ...b, [f]: v }))
-        setBillingLoading((l) => ({ ...l, [f]: false }))
-      })
-    })
+  const displayField = (v: any) => {
+    if (v === '__ERROR__') return 'Error'
+    if (v === undefined) return '404 Not Found'
+    if (v === '') return 'N/A'
+    return String(v)
+  }
 
-    // load overview summary from student profile
-    ;(async () => {
-      const studSnap = await getDoc(doc(db, 'Students', abbr))
-      const studData = studSnap.exists() ? (studSnap.data() as any) : {}
-      if (!mounted) return
-      setOverview({
-        joint: studData.jointDate || '',
-        last: studData.lastSession || '',
-        total: studData.totalSessions ?? 0,
-      })
-      setOverviewLoading(false)
-      setLoading(false)
-    })()
+  const loading =
+    Object.values(personalLoading).some((v) => v) ||
+    Object.values(billingLoading).some((v) => v) ||
+    overviewLoading
 
-    return () => {
-      mounted = false
-    }
-  }, [open, abbr, account])
-
+  if (!open) return null
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle sx={{ textAlign: 'left' }}>{account}</DialogTitle>
-      <DialogContent sx={{ display: 'flex', height: '70vh' }}>
-        {loading ? (
-          <Box
-            sx={{
-              flexGrow: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <CircularProgress />
-          </Box>
-        ) : (
-          <>
+    <StudentDialogErrorBoundary>
+      <FloatingWindow onClose={onClose} title={title}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
+          <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative' }}>
+            {loading && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  bgcolor: 'background.paper',
+                  zIndex: 1,
+                }}
+              >
+                <CircularProgress />
+              </Box>
+            )}
+
             <Box
               sx={{
                 flexGrow: 1,
                 pr: 3,
                 overflowY: 'auto',
                 textAlign: 'left',
+                display: loading ? 'none' : 'block',
               }}
             >
               <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
@@ -197,24 +180,24 @@ export default function OverviewTab({
                 <Typography variant="h6">
                   {(personalLoading.firstName || personalLoading.lastName)
                     ? 'Loading…'
-                    : `${personal.firstName} ${personal.lastName}`}
+                    : (() => {
+                        const first = displayField(personal.firstName)
+                        const last = displayField(personal.lastName)
+                        const both = `${first} ${last}`.trim()
+                        return both === '404 Not Found 404 Not Found'
+                          ? '404 Not Found'
+                          : both
+                      })()}
                 </Typography>
 
                 <Typography variant="subtitle2">
                   Gender {personalLoading.sex && <CircularProgress size={14} />}
                 </Typography>
-                {personalLoading.sex ? (
-                  <Typography variant="h6">Loading…</Typography>
-                ) : (
-                  <InlineEdit
-                    value={personal.sex}
-                    fieldPath={`Students/${abbr}/sex`}
-                    fieldKey="sex"
-                    editable={serviceMode}
-                    type="select"
-                    options={['Male', 'Female', 'Other']}
-                  />
-                )}
+                <Typography variant="h6">
+                  {personalLoading.sex
+                    ? 'Loading…'
+                    : displayField(personal.sex)}
+                </Typography>
 
                 <Typography variant="subtitle2">
                   Joint Date {overviewLoading && <CircularProgress size={14} />}
@@ -254,42 +237,32 @@ export default function OverviewTab({
                 {billingLoading.voucherBalance ? (
                   <Typography variant="h6">Loading…</Typography>
                 ) : (
-                  <Typography variant="h6">
-                    {billing.voucherBalance ?? '0'}
-                  </Typography>
+                  <Typography variant="h6">{billing.voucherBalance ?? '-'}</Typography>
                 )}
               </Box>
 
-              <Box sx={{ display: tab === 1 ? 'block' : 'none' }}>
-                <PersonalTab
-                  abbr={abbr}
-                  personal={personal}
-                  jointDate={overview.joint}
-                  totalSessions={overview.total}
-                  serviceMode={serviceMode}
-                />
-              </Box>
+              <PersonalTab
+                abbr={abbr}
+                serviceMode={serviceMode}
+                onPersonal={handlePersonal}
+                style={{ display: tab === 1 ? 'block' : 'none' }}
+              />
 
-              <Box sx={{ display: tab === 2 ? 'block' : 'none' }}>
-                <SessionsTab
-                  abbr={abbr}
-                  account={account}
-                  jointDate={overview.joint}
-                  lastSession={overview.last}
-                  totalSessions={overview.total}
-                  onSummary={handleSummary}
-                />
-              </Box>
+              <SessionsTab
+                abbr={abbr}
+                account={account}
+                onSummary={handleSummary}
+                onTitle={setTitle}
+                style={{ display: tab === 2 ? 'block' : 'none' }}
+              />
 
-              <Box sx={{ display: tab === 3 ? 'block' : 'none' }}>
-                <BillingTab
-                  abbr={abbr}
-                  account={account}
-                  billing={billing}
-                  serviceMode={serviceMode}
-                  onBalanceDue={handleBalanceDue}
-                />
-              </Box>
+              <BillingTab
+                abbr={abbr}
+                account={account}
+                serviceMode={serviceMode}
+                onBilling={handleBilling}
+                style={{ display: tab === 3 ? 'block' : 'none' }}
+              />
             </Box>
 
             <Tabs
@@ -301,18 +274,19 @@ export default function OverviewTab({
                 borderColor: 'divider',
                 minWidth: 140,
                 alignItems: 'flex-end',
+                display: loading ? 'none' : 'flex',
               }}
             >
               {['Overview', 'Personal', 'Sessions', 'Billing'].map((l) => (
                 <Tab key={l} label={l} sx={{ textAlign: 'right' }} />
               ))}
             </Tabs>
-          </>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Close</Button>
-      </DialogActions>
-    </Dialog>
+          </Box>
+          <Box sx={{ textAlign: 'right', mt: 1 }}>
+            <Button onClick={onClose}>Close</Button>
+          </Box>
+        </Box>
+      </FloatingWindow>
+    </StudentDialogErrorBoundary>
   )
 }

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -143,8 +143,8 @@ export default function OverviewTab({
   return (
     <StudentDialogErrorBoundary>
       <FloatingWindow onClose={onClose} title={title}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
-          <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%', maxHeight: '100%', maxWidth: '100%', overflow: 'hidden' }}>
+          <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative', alignItems: 'flex-start', maxHeight: '100%', maxWidth: '100%' }}>
             {loading && (
               <Box
                 sx={{
@@ -165,9 +165,11 @@ export default function OverviewTab({
               sx={{
                 flexGrow: 1,
                 pr: 3,
-                overflowY: 'auto',
+                overflow: 'auto',
                 textAlign: 'left',
                 display: loading ? 'none' : 'block',
+                maxHeight: '100%',
+                maxWidth: '100%',
               }}
             >
               <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
@@ -281,9 +283,6 @@ export default function OverviewTab({
                 <Tab key={l} label={l} sx={{ textAlign: 'right' }} />
               ))}
             </Tabs>
-          </Box>
-          <Box sx={{ textAlign: 'right', mt: 1 }}>
-            <Button onClick={onClose}>Close</Button>
           </Box>
         </Box>
       </FloatingWindow>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -56,6 +56,7 @@ export default function OverviewTab({
   console.log('OverviewTab rendered for', abbr)
   const [tab, setTab] = useState(0)
   const [title, setTitle] = useState(account)
+  const [actions, setActions] = useState<React.ReactNode | null>(null)
 
   // personal summary streamed from PersonalTab
   const [personal, setPersonal] = useState<any>({})
@@ -116,6 +117,7 @@ export default function OverviewTab({
       setOverviewLoading(true)
       setTab(0)
       setTitle(account)
+      setActions(null)
     }
   }, [open])
 
@@ -129,8 +131,7 @@ export default function OverviewTab({
 
   const displayField = (v: any) => {
     if (v === '__ERROR__') return 'Error'
-    if (v === undefined) return '404 Not Found'
-    if (v === '') return 'N/A'
+    if (v === undefined || v === null || v === '') return 'N/A'
     return String(v)
   }
 
@@ -142,7 +143,7 @@ export default function OverviewTab({
   if (!open) return null
   return (
     <StudentDialogErrorBoundary>
-      <FloatingWindow onClose={onClose} title={title}>
+      <FloatingWindow onClose={onClose} title={title} actions={actions}>
         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%', maxHeight: '100%', maxWidth: '100%', overflow: 'hidden' }}>
           <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative', alignItems: 'flex-start', maxHeight: '100%', maxWidth: '100%' }}>
             {loading && (
@@ -186,9 +187,7 @@ export default function OverviewTab({
                         const first = displayField(personal.firstName)
                         const last = displayField(personal.lastName)
                         const both = `${first} ${last}`.trim()
-                        return both === '404 Not Found 404 Not Found'
-                          ? '404 Not Found'
-                          : both
+                        return both === 'N/A N/A' ? 'N/A' : both
                       })()}
                 </Typography>
 
@@ -256,6 +255,7 @@ export default function OverviewTab({
                 onSummary={handleSummary}
                 onTitle={setTitle}
                 onClose={onClose}
+                onActions={setActions}
                 style={{ display: tab === 2 ? 'block' : 'none' }}
               />
 

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -15,6 +15,9 @@ import SessionsTab from './SessionsTab'
 
 console.log('=== StudentDialog loaded version 1.1 ===')
 
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
+
 class StudentDialogErrorBoundary extends React.Component<
   { children: React.ReactNode },
   { error: Error | null }
@@ -44,6 +47,7 @@ export interface OverviewTabProps {
   open: boolean
   onClose: () => void
   serviceMode: boolean
+  onPopDetail?: (s: any) => void
 }
 
 export default function OverviewTab({
@@ -52,6 +56,7 @@ export default function OverviewTab({
   open,
   onClose,
   serviceMode,
+  onPopDetail,
 }: OverviewTabProps) {
   console.log('OverviewTab rendered for', abbr)
   const [tab, setTab] = useState(0)
@@ -226,7 +231,7 @@ export default function OverviewTab({
                 ) : (
                   <Typography variant="h6">
                     {billing.balanceDue != null
-                      ? `$${(Number(billing.balanceDue) || 0).toFixed(2)}`
+                      ? formatCurrency(Number(billing.balanceDue) || 0)
                       : '-'}
                   </Typography>
                 )}
@@ -238,7 +243,11 @@ export default function OverviewTab({
                 {billingLoading.voucherBalance ? (
                   <Typography variant="h6">Loading…</Typography>
                 ) : (
-                  <Typography variant="h6">{billing.voucherBalance ?? '-'}</Typography>
+                  <Typography variant="h6">
+                    {billing.voucherBalance != null
+                      ? formatCurrency(Number(billing.voucherBalance) || 0)
+                      : '-'}
+                  </Typography>
                 )}
               </Box>
 
@@ -254,8 +263,8 @@ export default function OverviewTab({
                 account={account}
                 onSummary={handleSummary}
                 onTitle={setTitle}
-                onClose={onClose}
                 onActions={setActions}
+                onPopDetail={onPopDetail}
                 style={{ display: tab === 2 ? 'block' : 'none' }}
               />
 

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -311,8 +311,7 @@ export default function PersonalTab({
 
   const displayField = (v: any) => {
     if (v === '__ERROR__') return 'Error'
-    if (v === undefined) return '404 Not Found'
-    if (v === '') return 'N/A'
+    if (v === undefined || v === null || v === '') return 'N/A'
     return String(v)
   }
 
@@ -321,8 +320,8 @@ export default function PersonalTab({
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Personal Information
       </Typography>
-      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-        <Box sx={{ flex: 1 }}>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+        <Box sx={{ width: 260 }}>
           <Typography variant="subtitle2">First Name</Typography>
           {loading.firstName ? (
             <Typography variant="h6">Loading…</Typography>
@@ -341,7 +340,7 @@ export default function PersonalTab({
             />
           )}
         </Box>
-        <Box sx={{ flex: 1 }}>
+        <Box sx={{ width: 260 }}>
           <Typography variant="subtitle2">Last Name</Typography>
           {loading.lastName ? (
             <Typography variant="h6">Loading…</Typography>
@@ -362,8 +361,8 @@ export default function PersonalTab({
         </Box>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-        <Box sx={{ flex: 1 }}>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+        <Box sx={{ width: 160 }}>
           <Typography variant="subtitle2">Gender</Typography>
           {loading.sex ? (
             <Typography variant="h6">Loading…</Typography>
@@ -383,11 +382,11 @@ export default function PersonalTab({
             />
           )}
         </Box>
-        <Box sx={{ flex: 1 }}>
+        <Box sx={{ width: 160 }}>
           <Typography variant="subtitle2">Age</Typography>
           <Typography variant="h6">{age || '–'}</Typography>
         </Box>
-        <Box sx={{ flex: 1 }}>
+        <Box sx={{ width: 200 }}>
           <Typography variant="subtitle2">Birth Date</Typography>
           {loading.birthDate ? (
             <Typography variant="h6">Loading…</Typography>
@@ -408,7 +407,7 @@ export default function PersonalTab({
         </Box>
       </Box>
 
-      <Box mb={2}>
+      <Box mb={2} sx={{ width: 260 }}>
         <Typography variant="subtitle2">ID No.</Typography>
         {loading.hkid ? (
           <Typography variant="h6">Loading…</Typography>
@@ -442,7 +441,7 @@ export default function PersonalTab({
       </Typography>
 
       {/* Contact Number */}
-      <Box mb={2}>
+      <Box mb={2} sx={{ width: 260 }}>
         <Typography variant="subtitle2">Contact Number</Typography>
         {loading.contactNumber ? (
           <Typography variant="h6">Loading…</Typography>
@@ -489,7 +488,7 @@ export default function PersonalTab({
           >
             {fields.contactNumber.countryCode === undefined &&
             fields.contactNumber.phoneNumber === undefined
-              ? '404 Not Found'
+              ? 'N/A'
               : `+${displayField(fields.contactNumber.countryCode)} ${displayField(
                   fields.contactNumber.phoneNumber,
                 )}`}
@@ -498,7 +497,7 @@ export default function PersonalTab({
       </Box>
 
       {/* Email Address */}
-      <Box mb={2}>
+      <Box mb={2} sx={{ width: 260 }}>
         <Typography variant="subtitle2">Email Address</Typography>
         {loading.emailAddress ? (
           <Typography variant="h6">Loading…</Typography>
@@ -538,7 +537,7 @@ export default function PersonalTab({
       </Box>
 
       {/* Contact Address */}
-      <Box mb={2}>
+      <Box mb={2} sx={{ width: 260 }}>
         <Typography variant="subtitle2">Contact Address</Typography>
         {loading.address ? (
           <Typography variant="h6">Loading…</Typography>

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -320,7 +320,14 @@ export default function PersonalTab({
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Personal Information
       </Typography>
-      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 260px)',
+          gap: 2,
+          mb: 2,
+        }}
+      >
         <Box sx={{ width: 260 }}>
           <Typography
             variant="subtitle2"
@@ -381,7 +388,14 @@ export default function PersonalTab({
         </Box>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 160px)',
+          gap: 2,
+          mb: 2,
+        }}
+      >
         <Box sx={{ width: 160 }}>
           <Typography
             variant="subtitle2"

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -320,11 +320,21 @@ export default function PersonalTab({
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Personal Information
       </Typography>
-      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
         <Box sx={{ width: 260 }}>
-          <Typography variant="subtitle2">First Name</Typography>
+          <Typography
+            variant="subtitle2"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+          >
+            First Name:
+          </Typography>
           {loading.firstName ? (
-            <Typography variant="h6">Loading…</Typography>
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
+              Loading…
+            </Typography>
           ) : (
             <InlineEdit
               value={fields.firstName}
@@ -341,9 +351,19 @@ export default function PersonalTab({
           )}
         </Box>
         <Box sx={{ width: 260 }}>
-          <Typography variant="subtitle2">Last Name</Typography>
+          <Typography
+            variant="subtitle2"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+          >
+            Last Name:
+          </Typography>
           {loading.lastName ? (
-            <Typography variant="h6">Loading…</Typography>
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
+              Loading…
+            </Typography>
           ) : (
             <InlineEdit
               value={fields.lastName}
@@ -361,11 +381,21 @@ export default function PersonalTab({
         </Box>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
         <Box sx={{ width: 160 }}>
-          <Typography variant="subtitle2">Gender</Typography>
+          <Typography
+            variant="subtitle2"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+          >
+            Gender:
+          </Typography>
           {loading.sex ? (
-            <Typography variant="h6">Loading…</Typography>
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
+              Loading…
+            </Typography>
           ) : (
             <InlineEdit
               value={fields.sex}
@@ -383,13 +413,33 @@ export default function PersonalTab({
           )}
         </Box>
         <Box sx={{ width: 160 }}>
-          <Typography variant="subtitle2">Age</Typography>
-          <Typography variant="h6">{age || '–'}</Typography>
+          <Typography
+            variant="subtitle2"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+          >
+            Age:
+          </Typography>
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            {age || '–'}
+          </Typography>
         </Box>
         <Box sx={{ width: 200 }}>
-          <Typography variant="subtitle2">Birth Date</Typography>
+          <Typography
+            variant="subtitle2"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+          >
+            Birth Date:
+          </Typography>
           {loading.birthDate ? (
-            <Typography variant="h6">Loading…</Typography>
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
+              Loading…
+            </Typography>
           ) : (
             <InlineEdit
               value={fields.birthDate}
@@ -408,9 +458,19 @@ export default function PersonalTab({
       </Box>
 
       <Box mb={2} sx={{ width: 260 }}>
-        <Typography variant="subtitle2">ID No.</Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          ID No.:
+        </Typography>
         {loading.hkid ? (
-          <Typography variant="h6">Loading…</Typography>
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            Loading…
+          </Typography>
         ) : editingHKID ? (
           <TextField
             value={hkidDraft}
@@ -428,7 +488,7 @@ export default function PersonalTab({
         ) : (
           <Typography
             variant="h6"
-            sx={{ cursor: 'pointer' }}
+            sx={{ cursor: 'pointer', fontFamily: 'Newsreader', fontWeight: 500 }}
             onClick={() => setEditingHKID(true)}
           >
             {displayField(fields.hkid)}
@@ -442,9 +502,19 @@ export default function PersonalTab({
 
       {/* Contact Number */}
       <Box mb={2} sx={{ width: 260 }}>
-        <Typography variant="subtitle2">Contact Number</Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Contact Number:
+        </Typography>
         {loading.contactNumber ? (
-          <Typography variant="h6">Loading…</Typography>
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            Loading…
+          </Typography>
         ) : editingPhone ? (
           <Stack direction="row" spacing={1}>
             <TextField
@@ -483,7 +553,7 @@ export default function PersonalTab({
         ) : (
           <Typography
             variant="h6"
-            sx={{ cursor: 'pointer' }}
+            sx={{ cursor: 'pointer', fontFamily: 'Newsreader', fontWeight: 500 }}
             onClick={() => setEditingPhone(true)}
           >
             {fields.contactNumber.countryCode === undefined &&
@@ -498,9 +568,19 @@ export default function PersonalTab({
 
       {/* Email Address */}
       <Box mb={2} sx={{ width: 260 }}>
-        <Typography variant="subtitle2">Email Address</Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Email Address:
+        </Typography>
         {loading.emailAddress ? (
-          <Typography variant="h6">Loading…</Typography>
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            Loading…
+          </Typography>
         ) : editingEmail ? (
           <Stack direction="row" spacing={1}>
             <TextField
@@ -528,7 +608,7 @@ export default function PersonalTab({
         ) : (
           <Typography
             variant="h6"
-            sx={{ cursor: 'pointer' }}
+            sx={{ cursor: 'pointer', fontFamily: 'Newsreader', fontWeight: 500 }}
             onClick={() => setEditingEmail(true)}
           >
             {displayField(fields.emailAddress)}
@@ -538,9 +618,19 @@ export default function PersonalTab({
 
       {/* Contact Address */}
       <Box mb={2} sx={{ width: 260 }}>
-        <Typography variant="subtitle2">Contact Address</Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Contact Address:
+        </Typography>
         {loading.address ? (
-          <Typography variant="h6">Loading…</Typography>
+          <Typography
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            Loading…
+          </Typography>
         ) : editingAddr ? (
           <Box>
             <TextField
@@ -598,19 +688,34 @@ export default function PersonalTab({
           </Box>
         ) : (
           <Box sx={{ cursor: 'pointer' }} onClick={() => setEditingAddr(true)}>
-            <Typography variant="h6">
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
               {displayField(fields.address.addressLine1)}
             </Typography>
-            <Typography variant="h6">
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
               {displayField(fields.address.addressLine2)}
             </Typography>
-            <Typography variant="h6">
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
               {displayField(fields.address.addressLine3)}
             </Typography>
-            <Typography variant="h6">
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
               {displayField(fields.address.district)}
             </Typography>
-            <Typography variant="h6">
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+            >
               {displayField(fields.address.region)}
             </Typography>
           </Box>

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -1,58 +1,623 @@
 // components/StudentDialog/PersonalTab.tsx
 
-import React from 'react'
-import { Box, Typography } from '@mui/material'
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Typography,
+  TextField,
+  MenuItem,
+  Button,
+  Stack,
+} from '@mui/material'
 import InlineEdit from '../../common/InlineEdit'
+import { collection, getDocs, query, orderBy, limit, doc, setDoc } from 'firebase/firestore'
+import { db } from '../../lib/firebase'
 
-const LABELS: Record<string, string> = {
-  firstName: 'First Name',
-  lastName: 'Last Name',
-  sex: 'Gender',
-  birthDate: 'Birth Date',
-}
+console.log('=== StudentDialog loaded version 1.1 ===')
+
+// PersonalTab owns all personal information for a student. It fetches the
+// latest values from Firestore and streams key fields upward to OverviewTab via
+// `onPersonal` so OverviewTab can present them without duplicating logic.
+
+const REGION_OPTIONS = ['Hong Kong', 'Kowloon', 'New Territories']
 
 export default function PersonalTab({
   abbr,
-  personal,
-  jointDate,
-  totalSessions,
   serviceMode,
+  onPersonal,
+  style,
 }: {
   abbr: string
-  personal: any
-  jointDate?: string
-  totalSessions?: number
   serviceMode: boolean
+  onPersonal?: (p: Partial<{ firstName: string; lastName: string; sex: string; birthDate: string }>) => void
+  style?: React.CSSProperties
 }) {
+  console.log('Rendering PersonalTab for', abbr)
+  const [fields, setFields] = useState<any>({
+    firstName: undefined,
+    lastName: undefined,
+    sex: undefined,
+    birthDate: undefined,
+    hkid: undefined,
+    contactNumber: { countryCode: undefined, phoneNumber: undefined },
+    emailAddress: undefined,
+    address: {
+      addressLine1: undefined,
+      addressLine2: undefined,
+      addressLine3: undefined,
+      district: undefined,
+      region: undefined,
+    },
+  })
+
+  const [loading, setLoading] = useState<any>({
+    firstName: true,
+    lastName: true,
+    sex: true,
+    birthDate: true,
+    hkid: true,
+    contactNumber: true,
+    emailAddress: true,
+    address: true,
+  })
+
+  // helper to load latest doc from a subcollection
+  const loadLatest = async (sub: string) => {
+    try {
+      const snap = await getDocs(
+        query(collection(db, 'Students', abbr, sub), orderBy('timestamp', 'desc'), limit(1)),
+      )
+      return snap.empty ? null : snap.docs[0].data()
+    } catch (e) {
+      console.error(`load ${sub} failed`, e)
+      return { __error: true }
+    }
+  }
+
+  useEffect(() => {
+    console.log('PersonalTab effect: load latest fields for', abbr)
+    let cancelled = false
+    ;(async () => {
+      const basicFields = ['firstName', 'lastName', 'sex', 'birthDate']
+      await Promise.all(
+        basicFields.map(async (f) => {
+          try {
+            const data: any = await loadLatest(f)
+            if (cancelled) return
+            const val = data?.__error ? '__ERROR__' : data ? data[f] : undefined
+            setFields((p: any) => ({ ...p, [f]: val }))
+            setLoading((l: any) => {
+              const next = { ...l, [f]: false }
+              console.log('Loading flags now:', next)
+              return next
+            })
+            onPersonal?.({ [f]: val === '__ERROR__' ? undefined : val })
+          } catch (e) {
+            console.error(`basic field ${f} load failed`, e)
+            setFields((p: any) => ({ ...p, [f]: '__ERROR__' }))
+            setLoading((l: any) => {
+              const next = { ...l, [f]: false }
+              console.log('Loading flags now:', next)
+              return next
+            })
+            onPersonal?.({ [f]: undefined })
+          }
+        }),
+      )
+
+      try {
+        const hkidData: any = await loadLatest('HKID')
+        if (!cancelled) {
+          const val = hkidData?.__error ? '__ERROR__' : hkidData?.idNumber
+          setFields((p: any) => ({ ...p, hkid: val }))
+        }
+      } catch (e) {
+        console.error('HKID load failed', e)
+        if (!cancelled) setFields((p: any) => ({ ...p, hkid: '__ERROR__' }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, hkid: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+
+      try {
+        const phoneData: any = await loadLatest('contactNumber')
+        if (!cancelled) {
+          const val = phoneData?.__error
+            ? { countryCode: '__ERROR__', phoneNumber: '__ERROR__' }
+            : {
+                countryCode: phoneData?.countryCode,
+                phoneNumber: phoneData?.phoneNumber,
+              }
+          setFields((p: any) => ({ ...p, contactNumber: val }))
+        }
+      } catch (e) {
+        console.error('contact number load failed', e)
+        if (!cancelled)
+          setFields((p: any) => ({
+            ...p,
+            contactNumber: { countryCode: '__ERROR__', phoneNumber: '__ERROR__' },
+          }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, contactNumber: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+
+      try {
+        const emailData: any = await loadLatest('emailAddress')
+        if (!cancelled) {
+          const val = emailData?.__error ? '__ERROR__' : emailData?.emailAddress
+          setFields((p: any) => ({ ...p, emailAddress: val }))
+        }
+      } catch (e) {
+        console.error('email load failed', e)
+        if (!cancelled) setFields((p: any) => ({ ...p, emailAddress: '__ERROR__' }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, emailAddress: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+
+      try {
+        const addrData: any = await loadLatest('Address')
+        if (!cancelled) {
+          const val = addrData?.__error
+            ? {
+                addressLine1: '__ERROR__',
+                addressLine2: '__ERROR__',
+                addressLine3: '__ERROR__',
+                district: '__ERROR__',
+                region: '__ERROR__',
+              }
+            : {
+                addressLine1: addrData?.addressLine1,
+                addressLine2: addrData?.addressLine2,
+                addressLine3: addrData?.addressLine3,
+                district: addrData?.district,
+                region: addrData?.region,
+              }
+          setFields((p: any) => ({ ...p, address: val }))
+        }
+      } catch (e) {
+        console.error('address load failed', e)
+        if (!cancelled)
+          setFields((p: any) => ({
+            ...p,
+            address: {
+              addressLine1: '__ERROR__',
+              addressLine2: '__ERROR__',
+              addressLine3: '__ERROR__',
+              district: '__ERROR__',
+              region: '__ERROR__',
+            },
+          }))
+      } finally {
+        if (!cancelled)
+          setLoading((l: any) => {
+            const next = { ...l, address: false }
+            console.log('Loading flags now:', next)
+            return next
+          })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [abbr, onPersonal])
+
+  const age = (() => {
+    if (!fields.birthDate || fields.birthDate === '__ERROR__') return ''
+    const bd = new Date(fields.birthDate)
+    if (isNaN(bd.getTime())) return ''
+    const diff = Date.now() - bd.getTime()
+    return String(Math.floor(diff / (365.25 * 24 * 60 * 60 * 1000)))
+  })()
+
+  const saveCustom = async (
+    sub: string,
+    prefix: string,
+    data: Record<string, any>,
+    onDone: (d: any) => void,
+  ) => {
+    try {
+      const snap = await getDocs(collection(db, 'Students', abbr, sub))
+      const idx = String(snap.size + 1).padStart(3, '0')
+      const today = new Date()
+      const yyyyMMdd = today.toISOString().slice(0, 10).replace(/-/g, '')
+      const docName = `${abbr}-${prefix}-${idx}-${yyyyMMdd}`
+      await setDoc(doc(db, 'Students', abbr, sub, docName), {
+        ...data,
+        timestamp: today,
+      })
+      onDone(data)
+    } catch (e) {
+      console.error('Save failed', e)
+    }
+  }
+
+  const [editingPhone, setEditingPhone] = useState(false)
+  const [phoneDraft, setPhoneDraft] = useState({ countryCode: '', phoneNumber: '' })
+  const [editingEmail, setEditingEmail] = useState(false)
+  const [emailDraft, setEmailDraft] = useState('')
+  const [editingAddr, setEditingAddr] = useState(false)
+  const [addrDraft, setAddrDraft] = useState({
+    addressLine1: '',
+    addressLine2: '',
+    addressLine3: '',
+    district: '',
+    region: '',
+  })
+  const [editingHKID, setEditingHKID] = useState(false)
+  const [hkidDraft, setHkidDraft] = useState('')
+
+  // handlers for editing start
+  useEffect(() => {
+    console.log('PersonalTab effect: populate edit drafts for', abbr)
+    if (editingPhone)
+      setPhoneDraft({
+        countryCode:
+          fields.contactNumber.countryCode &&
+          fields.contactNumber.countryCode !== '__ERROR__'
+            ? fields.contactNumber.countryCode
+            : '',
+        phoneNumber:
+          fields.contactNumber.phoneNumber &&
+          fields.contactNumber.phoneNumber !== '__ERROR__'
+            ? fields.contactNumber.phoneNumber
+            : '',
+      })
+    if (editingEmail)
+      setEmailDraft(
+        fields.emailAddress && fields.emailAddress !== '__ERROR__'
+          ? fields.emailAddress
+          : '',
+      )
+    if (editingAddr)
+      setAddrDraft({
+        addressLine1:
+          fields.address.addressLine1 && fields.address.addressLine1 !== '__ERROR__'
+            ? fields.address.addressLine1
+            : '',
+        addressLine2:
+          fields.address.addressLine2 && fields.address.addressLine2 !== '__ERROR__'
+            ? fields.address.addressLine2
+            : '',
+        addressLine3:
+          fields.address.addressLine3 && fields.address.addressLine3 !== '__ERROR__'
+            ? fields.address.addressLine3
+            : '',
+        district:
+          fields.address.district && fields.address.district !== '__ERROR__'
+            ? fields.address.district
+            : '',
+        region:
+          fields.address.region && fields.address.region !== '__ERROR__'
+            ? fields.address.region
+            : '',
+      })
+    if (editingHKID)
+      setHkidDraft(fields.hkid && fields.hkid !== '__ERROR__' ? fields.hkid : '')
+  }, [editingPhone, editingEmail, editingAddr, editingHKID])
+
+  const displayField = (v: any) => {
+    if (v === '__ERROR__') return 'Error'
+    if (v === undefined) return '404 Not Found'
+    if (v === '') return 'N/A'
+    return String(v)
+  }
+
   return (
-    <Box>
-      {Object.entries(personal)
-        .filter(([k]) => k !== 'abbr')
-        .map(([k, v]) => {
-          const path = `Students/${abbr}/${k}`
-          return (
-            <Box key={k} mb={2}>
-              <Typography variant="subtitle2">{LABELS[k]}</Typography>
-              <InlineEdit
-                value={v}
-                fieldPath={path}
-                fieldKey={k}
-                editable // always editable
-                serviceMode={serviceMode}
-                type={k === 'sex' ? 'select' : k === 'birthDate' ? 'date' : 'text'}
-                options={k === 'sex' ? ['Male', 'Female', 'Other'] : undefined}
-              />
-            </Box>
-          )
-        })}
-      <Box mb={2}>
-        <Typography variant="subtitle2">Joint Date</Typography>
-        <Typography variant="h6">{jointDate || '–'}</Typography>
+    <Box style={style} sx={{ textAlign: 'left' }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Personal Information
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">First Name</Typography>
+          {loading.firstName ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.firstName}
+              fieldPath={`Students/${abbr}/firstName`}
+              fieldKey="firstName"
+              editable
+              serviceMode={serviceMode}
+              type="text"
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, firstName: v }))
+                onPersonal?.({ firstName: v })
+              }}
+            />
+          )}
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Last Name</Typography>
+          {loading.lastName ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.lastName}
+              fieldPath={`Students/${abbr}/lastName`}
+              fieldKey="lastName"
+              editable
+              serviceMode={serviceMode}
+              type="text"
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, lastName: v }))
+                onPersonal?.({ lastName: v })
+              }}
+            />
+          )}
+        </Box>
       </Box>
+
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Gender</Typography>
+          {loading.sex ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.sex}
+              fieldPath={`Students/${abbr}/sex`}
+              fieldKey="sex"
+              editable
+              serviceMode={serviceMode}
+              type="select"
+              options={['Male', 'Female', 'Other']}
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, sex: v }))
+                onPersonal?.({ sex: v })
+              }}
+            />
+          )}
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Age</Typography>
+          <Typography variant="h6">{age || '–'}</Typography>
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2">Birth Date</Typography>
+          {loading.birthDate ? (
+            <Typography variant="h6">Loading…</Typography>
+          ) : (
+            <InlineEdit
+              value={fields.birthDate}
+              fieldPath={`Students/${abbr}/birthDate`}
+              fieldKey="birthDate"
+              editable
+              serviceMode={serviceMode}
+              type="date"
+              onSaved={(v) => {
+                setFields((p: any) => ({ ...p, birthDate: v }))
+                onPersonal?.({ birthDate: v })
+              }}
+            />
+          )}
+        </Box>
+      </Box>
+
       <Box mb={2}>
-        <Typography variant="subtitle2">Total Sessions</Typography>
-        <Typography variant="h6">{totalSessions ?? '–'}</Typography>
+        <Typography variant="subtitle2">ID No.</Typography>
+        {loading.hkid ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingHKID ? (
+          <TextField
+            value={hkidDraft}
+            onChange={(e) => setHkidDraft(e.target.value)}
+            onBlur={() => {
+              if (hkidDraft !== fields.hkid) {
+                saveCustom('HKID', 'hkid', { idNumber: hkidDraft }, () => {
+                  setFields((p: any) => ({ ...p, hkid: hkidDraft }))
+                })
+              }
+              setEditingHKID(false)
+            }}
+            size="small"
+          />
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{ cursor: 'pointer' }}
+            onClick={() => setEditingHKID(true)}
+          >
+            {displayField(fields.hkid)}
+          </Typography>
+        )}
+      </Box>
+
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Contact Information
+      </Typography>
+
+      {/* Contact Number */}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Contact Number</Typography>
+        {loading.contactNumber ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingPhone ? (
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label="Country Code"
+              type="number"
+              value={phoneDraft.countryCode}
+              onChange={(e) => setPhoneDraft((p) => ({ ...p, countryCode: e.target.value }))}
+              size="small"
+            />
+            <TextField
+              label="Phone Number"
+              type="number"
+              value={phoneDraft.phoneNumber}
+              onChange={(e) => setPhoneDraft((p) => ({ ...p, phoneNumber: e.target.value }))}
+              size="small"
+            />
+            <Button
+              onClick={() => {
+                saveCustom(
+                  'contactNumber',
+                  'phone',
+                  {
+                    countryCode: Number(phoneDraft.countryCode) || 0,
+                    phoneNumber: Number(phoneDraft.phoneNumber) || 0,
+                  },
+                  (d) => {
+                    setFields((p: any) => ({ ...p, contactNumber: d }))
+                  },
+                )
+                setEditingPhone(false)
+              }}
+            >
+              Save
+            </Button>
+          </Stack>
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{ cursor: 'pointer' }}
+            onClick={() => setEditingPhone(true)}
+          >
+            {fields.contactNumber.countryCode === undefined &&
+            fields.contactNumber.phoneNumber === undefined
+              ? '404 Not Found'
+              : `+${displayField(fields.contactNumber.countryCode)} ${displayField(
+                  fields.contactNumber.phoneNumber,
+                )}`}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Email Address */}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Email Address</Typography>
+        {loading.emailAddress ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingEmail ? (
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label="Email"
+              value={emailDraft}
+              onChange={(e) => setEmailDraft(e.target.value)}
+              size="small"
+            />
+            <Button
+              onClick={() => {
+                const valid = /.+@.+\..+/.test(emailDraft)
+                if (!valid) {
+                  alert('Invalid email')
+                  return
+                }
+                saveCustom('emailAddress', 'email', { emailAddress: emailDraft }, (d) => {
+                  setFields((p: any) => ({ ...p, emailAddress: d.emailAddress }))
+                })
+                setEditingEmail(false)
+              }}
+            >
+              Save
+            </Button>
+          </Stack>
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{ cursor: 'pointer' }}
+            onClick={() => setEditingEmail(true)}
+          >
+            {displayField(fields.emailAddress)}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Contact Address */}
+      <Box mb={2}>
+        <Typography variant="subtitle2">Contact Address</Typography>
+        {loading.address ? (
+          <Typography variant="h6">Loading…</Typography>
+        ) : editingAddr ? (
+          <Box>
+            <TextField
+              label="Address Line 1"
+              fullWidth
+              value={addrDraft.addressLine1}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, addressLine1: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              label="Address Line 2"
+              fullWidth
+              value={addrDraft.addressLine2}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, addressLine2: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              label="Address Line 3"
+              fullWidth
+              value={addrDraft.addressLine3}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, addressLine3: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              label="District"
+              fullWidth
+              value={addrDraft.district}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, district: e.target.value }))}
+              sx={{ mb: 1 }}
+            />
+            <TextField
+              select
+              label="Region"
+              fullWidth
+              value={addrDraft.region}
+              onChange={(e) => setAddrDraft((p) => ({ ...p, region: e.target.value }))}
+              sx={{ mb: 1 }}
+            >
+              {REGION_OPTIONS.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {r}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Button
+              onClick={() => {
+                saveCustom('Address', 'address', addrDraft, (d) => {
+                  setFields((p: any) => ({ ...p, address: d }))
+                })
+                setEditingAddr(false)
+              }}
+            >
+              Save
+            </Button>
+          </Box>
+        ) : (
+          <Box sx={{ cursor: 'pointer' }} onClick={() => setEditingAddr(true)}>
+            <Typography variant="h6">
+              {displayField(fields.address.addressLine1)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.addressLine2)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.addressLine3)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.district)}
+            </Typography>
+            <Typography variant="h6">
+              {displayField(fields.address.region)}
+            </Typography>
+          </Box>
+        )}
       </Box>
     </Box>
   )
 }
+

--- a/components/StudentDialog/PersonalTab.tsx
+++ b/components/StudentDialog/PersonalTab.tsx
@@ -317,7 +317,7 @@ export default function PersonalTab({
   }
 
   return (
-    <Box style={style} sx={{ textAlign: 'left' }}>
+    <Box style={style} sx={{ textAlign: 'left', maxWidth: '100%', maxHeight: '100%', overflow: 'auto' }}>
       <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
         Personal Information
       </Typography>

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Box, Typography, Button, IconButton } from '@mui/material'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import CloseIcon from '@mui/icons-material/Close'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
@@ -19,49 +20,64 @@ interface SessionDetailProps {
   session: any
   onBack: () => void
   onDetach?: () => void
+  onClose?: () => void
   detached?: boolean
 }
 
 // SessionDetail shows information for a single session. Editing is intended to
 // happen here (rather than inline in the sessions table) but is limited to
 // read-only fields for now.
-export default function SessionDetail({ session, onBack, onDetach, detached }: SessionDetailProps) {
+export default function SessionDetail({ session, onBack, onDetach, onClose, detached }: SessionDetailProps) {
   return (
     <Box sx={{ p: 2, width: '100%', height: '100%', position: 'relative' }}>
-      <Typography variant="h6" gutterBottom>
-        Session Detail
-      </Typography>
-      {!detached && onDetach && (
-        <IconButton
-          onClick={onDetach}
-          aria-label="detach session"
-          sx={{ position: 'absolute', top: 8, right: 8 }}
-        >
-          <OpenInNewIcon />
-        </IconButton>
-      )}
-      <Typography>Date: {formatDate(session.date)}</Typography>
-      <Typography>Time: {session.time}</Typography>
-      <Typography>Duration: {session.duration}</Typography>
-      <Typography>
-        Base Rate:{' '}
-        {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
-      </Typography>
-      <Typography>
-        Rate Charged:{' '}
-        {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
-      </Typography>
-      <Typography>Payment Status: {session.paymentStatus}</Typography>
-      {!detached && (
-        <Button
-          variant="text"
-          onClick={onBack}
-          aria-label="back to sessions"
-          sx={{ position: 'absolute', bottom: 8, left: 8 }}
-        >
+      <Box sx={{ height: '100%', overflow: 'auto', pb: '56px' }}>
+        <Typography variant="h6" gutterBottom>
+          Session Detail
+        </Typography>
+        <Typography>Date: {formatDate(session.date)}</Typography>
+        <Typography>Time: {session.time}</Typography>
+        <Typography>Duration: {session.duration}</Typography>
+        <Typography>
+          Base Rate{' '}
+          {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
+        </Typography>
+        <Typography>
+          Rate Charged{' '}
+          {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
+        </Typography>
+        <Typography>Payment Status: {session.paymentStatus}</Typography>
+      </Box>
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderTop: 1,
+          borderColor: 'divider',
+          p: 1,
+          bgcolor: 'background.paper',
+        }}
+      >
+        <Button variant="text" onClick={onBack} aria-label="back to sessions">
           ← Back
         </Button>
-      )}
+        <Box>
+          {!detached && onDetach && (
+            <IconButton onClick={onDetach} aria-label="detach session" sx={{ mr: 1 }}>
+              <OpenInNewIcon />
+            </IconButton>
+          )}
+          {onClose && (
+            <IconButton onClick={onClose} aria-label="close dialog">
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Box>
+      </Box>
     </Box>
   )
 }

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -26,16 +26,78 @@ export default function SessionDetail({ session, onBack }: SessionDetailProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
-        <Typography>Date: {formatDate(session.date)}</Typography>
-        <Typography>Time: {session.time}</Typography>
-        <Typography>Duration: {session.duration}</Typography>
-        <Typography>
-          Base Rate {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Date:
         </Typography>
-        <Typography>
-          Rate Charged {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+        >
+          {formatDate(session.date)}
         </Typography>
-        <Typography>Payment Status: {session.paymentStatus}</Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Time:
+        </Typography>
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+        >
+          {session.time}
+        </Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Duration:
+        </Typography>
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+        >
+          {session.duration}
+        </Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Base Rate:
+        </Typography>
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+        >
+          {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
+        </Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Rate Charged:
+        </Typography>
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+        >
+          {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
+        </Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+        >
+          Payment Status:
+        </Typography>
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+        >
+          {session.paymentStatus}
+        </Typography>
       </Box>
 
       <Box

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Box, Typography, Button } from '@mui/material'
+import { Box, Typography, Button, IconButton } from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
@@ -30,6 +31,15 @@ export default function SessionDetail({ session, onBack, onDetach, detached }: S
       <Typography variant="h6" gutterBottom>
         Session Detail
       </Typography>
+      {!detached && onDetach && (
+        <IconButton
+          onClick={onDetach}
+          aria-label="detach session"
+          sx={{ position: 'absolute', top: 8, right: 8 }}
+        >
+          <OpenInNewIcon />
+        </IconButton>
+      )}
       <Typography>Date: {formatDate(session.date)}</Typography>
       <Typography>Time: {session.time}</Typography>
       <Typography>Duration: {session.duration}</Typography>
@@ -50,16 +60,6 @@ export default function SessionDetail({ session, onBack, onDetach, detached }: S
           sx={{ position: 'absolute', bottom: 8, left: 8 }}
         >
           ← Back
-        </Button>
-      )}
-      {!detached && onDetach && (
-        <Button
-          variant="text"
-          onClick={onDetach}
-          aria-label="detach session"
-          sx={{ position: 'absolute', bottom: 8, right: 8 }}
-        >
-          Detach
         </Button>
       )}
     </Box>

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -1,6 +1,19 @@
 import React from 'react'
 import { Box, Typography, Button } from '@mui/material'
 
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
+
+const formatDate = (s: string) => {
+  const d = new Date(s)
+  if (isNaN(d.getTime())) return s
+  return d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
 interface SessionDetailProps {
   session: any
   onBack: () => void
@@ -13,28 +26,42 @@ interface SessionDetailProps {
 // read-only fields for now.
 export default function SessionDetail({ session, onBack, onDetach, detached }: SessionDetailProps) {
   return (
-    <Box sx={{ p: 2, width: '100%', height: '100%' }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-        {!detached && (
-          <Button variant="text" onClick={onBack} aria-label="back to sessions">
-            ← Back
-          </Button>
-        )}
-        {!detached && onDetach && (
-          <Button variant="text" onClick={onDetach} aria-label="detach session">
-            Detach
-          </Button>
-        )}
-      </Box>
+    <Box sx={{ p: 2, width: '100%', height: '100%', position: 'relative' }}>
       <Typography variant="h6" gutterBottom>
         Session Detail
       </Typography>
-      <Typography>Date: {session.date}</Typography>
+      <Typography>Date: {formatDate(session.date)}</Typography>
       <Typography>Time: {session.time}</Typography>
       <Typography>Duration: {session.duration}</Typography>
-      <Typography>Base Rate: {session.baseRate}</Typography>
-      <Typography>Rate Charged: {session.rateCharged}</Typography>
+      <Typography>
+        Base Rate:{' '}
+        {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
+      </Typography>
+      <Typography>
+        Rate Charged:{' '}
+        {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
+      </Typography>
       <Typography>Payment Status: {session.paymentStatus}</Typography>
+      {!detached && (
+        <Button
+          variant="text"
+          onClick={onBack}
+          aria-label="back to sessions"
+          sx={{ position: 'absolute', bottom: 8, left: 8 }}
+        >
+          ← Back
+        </Button>
+      )}
+      {!detached && onDetach && (
+        <Button
+          variant="text"
+          onClick={onDetach}
+          aria-label="detach session"
+          sx={{ position: 'absolute', bottom: 8, right: 8 }}
+        >
+          Detach
+        </Button>
+      )}
     </Box>
   )
 }

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { Box, Typography, Button, IconButton } from '@mui/material'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
-import CloseIcon from '@mui/icons-material/Close'
+import { Box, Typography, Button } from '@mui/material'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
@@ -19,44 +17,14 @@ const formatDate = (s: string) => {
 interface SessionDetailProps {
   session: any
   onBack: () => void
-  onDetach?: () => void
-  onClose?: () => void
-  detached?: boolean
 }
 
 // SessionDetail shows information for a single session. Editing is intended to
 // happen here (rather than inline in the sessions table) but is limited to
 // read-only fields for now.
-export default function SessionDetail({ session, onBack, onDetach, onClose, detached }: SessionDetailProps) {
+export default function SessionDetail({ session, onBack }: SessionDetailProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      {!detached && (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            p: 1,
-            borderBottom: 1,
-            borderColor: 'divider',
-          }}
-        >
-          <Typography variant="h6">Session Detail</Typography>
-          <Box>
-            {onDetach && (
-              <IconButton onClick={onDetach} aria-label="detach session" sx={{ mr: 1 }}>
-                <OpenInNewIcon />
-              </IconButton>
-            )}
-            {onClose && (
-              <IconButton onClick={onClose} aria-label="close dialog">
-                <CloseIcon />
-              </IconButton>
-            )}
-          </Box>
-        </Box>
-      )}
-
       <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
         <Typography>Date: {formatDate(session.date)}</Typography>
         <Typography>Time: {session.time}</Typography>

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -29,54 +29,60 @@ interface SessionDetailProps {
 // read-only fields for now.
 export default function SessionDetail({ session, onBack, onDetach, onClose, detached }: SessionDetailProps) {
   return (
-    <Box sx={{ p: 2, width: '100%', height: '100%', position: 'relative' }}>
-      <Box sx={{ height: '100%', overflow: 'auto', pb: '56px' }}>
-        <Typography variant="h6" gutterBottom>
-          Session Detail
-        </Typography>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {!detached && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            p: 1,
+            borderBottom: 1,
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="h6">Session Detail</Typography>
+          <Box>
+            {onDetach && (
+              <IconButton onClick={onDetach} aria-label="detach session" sx={{ mr: 1 }}>
+                <OpenInNewIcon />
+              </IconButton>
+            )}
+            {onClose && (
+              <IconButton onClick={onClose} aria-label="close dialog">
+                <CloseIcon />
+              </IconButton>
+            )}
+          </Box>
+        </Box>
+      )}
+
+      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
         <Typography>Date: {formatDate(session.date)}</Typography>
         <Typography>Time: {session.time}</Typography>
         <Typography>Duration: {session.duration}</Typography>
         <Typography>
-          Base Rate{' '}
-          {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
+          Base Rate {session.baseRate !== '-' ? formatCurrency(Number(session.baseRate)) : '-'}
         </Typography>
         <Typography>
-          Rate Charged{' '}
-          {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
+          Rate Charged {session.rateCharged !== '-' ? formatCurrency(Number(session.rateCharged)) : '-'}
         </Typography>
         <Typography>Payment Status: {session.paymentStatus}</Typography>
       </Box>
+
       <Box
         sx={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
           borderTop: 1,
           borderColor: 'divider',
           p: 1,
+          display: 'flex',
+          justifyContent: 'flex-start',
           bgcolor: 'background.paper',
         }}
       >
         <Button variant="text" onClick={onBack} aria-label="back to sessions">
           ← Back
         </Button>
-        <Box>
-          {!detached && onDetach && (
-            <IconButton onClick={onDetach} aria-label="detach session" sx={{ mr: 1 }}>
-              <OpenInNewIcon />
-            </IconButton>
-          )}
-          {onClose && (
-            <IconButton onClick={onClose} aria-label="close dialog">
-              <CloseIcon />
-            </IconButton>
-          )}
-        </Box>
       </Box>
     </Box>
   )

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -306,7 +306,16 @@ export default function SessionsTab({
     return <CircularProgress />
   }
   return (
-    <Box sx={{ textAlign: 'left', height: '100%', position: 'relative' }} style={style}>
+    <Box
+      sx={{
+        textAlign: 'left',
+        position: 'relative',
+        maxWidth: '100%',
+        maxHeight: '100%',
+        overflow: 'auto',
+      }}
+      style={style}
+    >
       {!detail && (
         <>
           <Button

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -74,15 +74,16 @@ export default function SessionsTab({
   const [popped, setPopped] = useState<any | null>(null)
 
   const allColumns = [
-    { key: 'date', label: 'Date' },
-    { key: 'time', label: 'Time' },
-    { key: 'duration', label: 'Duration' },
-    { key: 'sessionType', label: 'Session Type' },
-    { key: 'billingType', label: 'Billing Type' },
-    { key: 'baseRate', label: 'Base Rate' },
-    { key: 'rateCharged', label: 'Rate Charged' },
-    { key: 'paymentStatus', label: 'Payment Status' },
+    { key: 'date', label: 'Date', width: 110 },
+    { key: 'time', label: 'Time', width: 100 },
+    { key: 'duration', label: 'Duration', width: 110 },
+    { key: 'sessionType', label: 'Session Type', width: 150 },
+    { key: 'billingType', label: 'Billing Type', width: 150 },
+    { key: 'baseRate', label: 'Base Rate', width: 140 },
+    { key: 'rateCharged', label: 'Rate Charged', width: 140 },
+    { key: 'paymentStatus', label: 'Payment Status', width: 150 },
   ]
+  const colWidth = (key: string) => allColumns.find((c) => c.key === key)?.width
   const defaultCols = ['date', 'time', 'sessionType', 'rateCharged', 'paymentStatus']
   const [visibleCols, setVisibleCols] = useState<string[]>(defaultCols)
   const [period, setPeriod] = useState<'30' | '90' | 'all'>('all')
@@ -369,13 +370,16 @@ export default function SessionsTab({
             </Box>
           )}
 
-          <Table size="small">
+          <Table size="small" sx={{ tableLayout: 'fixed' }}>
             <TableHead>
               <TableRow>
                 {allColumns
                   .filter((c) => visibleCols.includes(c.key))
                   .map((c) => (
-                    <TableCell key={c.key} sx={{ typography: 'body2', fontWeight: 'normal' }}>
+                    <TableCell
+                      key={c.key}
+                      sx={{ typography: 'body2', fontWeight: 'normal', width: c.width }}
+                    >
                       {c.label}
                     </TableCell>
                   ))}
@@ -400,32 +404,44 @@ export default function SessionsTab({
                     sx={{ cursor: 'pointer' }}
                   >
                     {visibleCols.includes('date') && (
-                      <TableCell sx={{ typography: 'body2' }}>{s.date}</TableCell>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('date') }}>
+                        {s.date}
+                      </TableCell>
                     )}
                     {visibleCols.includes('time') && (
-                      <TableCell sx={{ typography: 'body2' }}>{s.time}</TableCell>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('time') }}>
+                        {s.time}
+                      </TableCell>
                     )}
                     {visibleCols.includes('duration') && (
-                      <TableCell sx={{ typography: 'body2' }}>{s.duration}</TableCell>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('duration') }}>
+                        {s.duration}
+                      </TableCell>
                     )}
                     {visibleCols.includes('sessionType') && (
-                      <TableCell sx={{ typography: 'body2' }}>{s.sessionType}</TableCell>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('sessionType') }}>
+                        {s.sessionType}
+                      </TableCell>
                     )}
                     {visibleCols.includes('billingType') && (
-                      <TableCell sx={{ typography: 'body2' }}>{s.billingType}</TableCell>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('billingType') }}>
+                        {s.billingType}
+                      </TableCell>
                     )}
                     {visibleCols.includes('baseRate') && (
-                      <TableCell sx={{ typography: 'body2' }}>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('baseRate') }}>
                         {s.baseRate !== '-' ? formatCurrency(Number(s.baseRate)) : '-'}
                       </TableCell>
                     )}
                     {visibleCols.includes('rateCharged') && (
-                      <TableCell sx={{ typography: 'body2' }}>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('rateCharged') }}>
                         {s.rateCharged !== '-' ? formatCurrency(Number(s.rateCharged)) : '-'}
                       </TableCell>
                     )}
                     {visibleCols.includes('paymentStatus') && (
-                      <TableCell sx={{ typography: 'body2' }}>{s.paymentStatus}</TableCell>
+                      <TableCell sx={{ typography: 'body2', width: colWidth('paymentStatus') }}>
+                        {s.paymentStatus}
+                      </TableCell>
                     )}
                   </TableRow>
                 ))}

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -412,9 +412,11 @@ export default function SessionsTab({
                       setDetail(s)
                       const idx = sessions.findIndex((r) => r.id === s.id)
                       const num = String(idx + 1).padStart(3, '0')
-                      onTitle?.(
-                        `${account} - Session #${num} | ${s.date} ${s.time}`,
+                      const titleDate = new Date(s.startMs).toLocaleDateString(
+                        undefined,
+                        { month: 'short', day: '2-digit', year: 'numeric' },
                       )
+                      onTitle?.(titleDate)
                       onActions?.(
                         <IconButton
                           onClick={(e) => {
@@ -480,16 +482,46 @@ export default function SessionsTab({
 
           <Box mt={2}>
             <Box mb={1}>
-              <Typography variant="subtitle2">Joint Date:</Typography>
-              <Typography variant="h6">{summary.jointDate || '–'}</Typography>
+              <Typography
+                variant="subtitle2"
+                sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+              >
+                Joint Date:
+              </Typography>
+              <Typography
+                variant="h6"
+                sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+              >
+                {summary.jointDate || '–'}
+              </Typography>
             </Box>
             <Box mb={1}>
-              <Typography variant="subtitle2">Last Session:</Typography>
-              <Typography variant="h6">{summary.lastSession || '–'}</Typography>
+              <Typography
+                variant="subtitle2"
+                sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+              >
+                Last Session:
+              </Typography>
+              <Typography
+                variant="h6"
+                sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+              >
+                {summary.lastSession || '–'}
+              </Typography>
             </Box>
             <Box mb={1}>
-              <Typography variant="subtitle2">Total Sessions:</Typography>
-              <Typography variant="h6">{summary.totalSessions ?? '–'}</Typography>
+              <Typography
+                variant="subtitle2"
+                sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
+              >
+                Total Sessions:
+              </Typography>
+              <Typography
+                variant="h6"
+                sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+              >
+                {summary.totalSessions ?? '–'}
+              </Typography>
             </Box>
           </Box>
         </>

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -416,7 +416,8 @@ export default function SessionsTab({
                         undefined,
                         { month: 'short', day: '2-digit', year: 'numeric' },
                       )
-                      onTitle?.(titleDate)
+                      const title = `${account} - #${num} | ${titleDate} ${s.time}`
+                      onTitle?.(title)
                       onActions?.(
                         <IconButton
                           onClick={(e) => {

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -57,12 +57,14 @@ export default function SessionsTab({
   account,
   onSummary,
   onTitle,
+  onClose,
   style,
 }: {
   abbr: string
   account: string
   onSummary?: (s: { jointDate: string; lastSession: string; totalSessions: number }) => void
   onTitle?: (t: string) => void
+  onClose?: () => void
   style?: React.CSSProperties
 }) {
   console.log('Rendering SessionsTab for', abbr)
@@ -459,6 +461,7 @@ export default function SessionsTab({
             setDetail(null)
             onTitle?.(account)
           }}
+          onClose={onClose}
         />
       )}
       {popped && (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,18 +3,24 @@ import { SessionProvider, useSession } from 'next-auth/react';
 import { SnackbarProvider } from 'notistack';
 import type { AppProps } from 'next/app';
 import { setupClientLogging } from '../lib/clientLogger';
+import { Newsreader, Cantata_One } from 'next/font/google';
 
 if (typeof window !== 'undefined') {
   setupClientLogging();
 }
 
+const newsreader = Newsreader({ subsets: ['latin'], weight: ['200', '500'] });
+const cantata = Cantata_One({ subsets: ['latin'] });
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <SessionProvider session={pageProps.session}>
-      <SnackbarProvider maxSnack={3}>
-        <Component {...pageProps} />
-      </SnackbarProvider>
-    </SessionProvider>
+    <div className={`${newsreader.className} ${cantata.className}`}>
+      <SessionProvider session={pageProps.session}>
+        <SnackbarProvider maxSnack={3}>
+          <Component {...pageProps} />
+        </SnackbarProvider>
+      </SessionProvider>
+    </div>
   );
 }
 

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -268,11 +268,13 @@ export default function CoachingSessions() {
 
       {detached && (
         <FloatingWindow
-          title={new Date(detached.startMs).toLocaleDateString(undefined, {
+          title={`${detached.account} - #${detached.number} | ${new Date(
+            detached.startMs
+          ).toLocaleDateString(undefined, {
             month: 'short',
             day: '2-digit',
             year: 'numeric',
-          })}
+          })} ${detached.time}`}
           onClose={() => setDetached(null)}
         >
           <SessionDetail session={detached} onBack={() => setDetached(null)} />

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -268,7 +268,11 @@ export default function CoachingSessions() {
 
       {detached && (
         <FloatingWindow
-          title={`${detached.account} - Session #${detached.number} | ${detached.date} ${detached.time}`}
+          title={new Date(detached.startMs).toLocaleDateString(undefined, {
+            month: 'short',
+            day: '2-digit',
+            year: 'numeric',
+          })}
           onClose={() => setDetached(null)}
         >
           <SessionDetail session={detached} onBack={() => setDetached(null)} />

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -25,6 +25,8 @@ import {
   Snackbar,
 } from '@mui/material'
 import OverviewTab from '../../../components/StudentDialog/OverviewTab'
+import SessionDetail from '../../../components/StudentDialog/SessionDetail'
+import FloatingWindow from '../../../components/StudentDialog/FloatingWindow'
 import { clearSessionSummaries } from '../../../lib/sessionStats'
 import BatchRenamePayments from '../../../tools/BatchRenamePayments'
 
@@ -48,6 +50,7 @@ export default function CoachingSessions() {
   const [toolsAnchor, setToolsAnchor] = useState<null | HTMLElement>(null)
   const [scanMessage, setScanMessage] = useState('')
   const [renameOpen, setRenameOpen] = useState(false)
+  const [detached, setDetached] = useState<any | null>(null)
 
   const openToolsMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
     setToolsAnchor(e.currentTarget)
@@ -259,7 +262,17 @@ export default function CoachingSessions() {
           open
           onClose={() => setSelected(null)}
           serviceMode={serviceMode}
+          onPopDetail={(s) => setDetached(s)}
         />
+      )}
+
+      {detached && (
+        <FloatingWindow
+          title={`${detached.account} - Session #${detached.number} | ${detached.date} ${detached.time}`}
+          onClose={() => setDetached(null)}
+        >
+          <SessionDetail session={detached} onBack={() => setDetached(null)} />
+        </FloatingWindow>
       )}
 
       <Snackbar


### PR DESCRIPTION
## Summary
- Stop OverviewTab from querying Firestore directly; child tabs now fetch and stream data upward
- Expand PersonalTab with HKID, contact number, email address and full contact address fields
- BillingTab now owns billing calculations and provides Balance Due and Voucher Balance to OverviewTab
- Display `N/A` or `404 Not Found` when student data is missing instead of leaving the dialog stuck
- Always clear loading flags after each fetch in PersonalTab, BillingTab and SessionsTab so the dialog spinner never hangs
- Add global error boundary and extensive console logging to confirm latest deployment and loading-state updates
- Keep Personal, Sessions and Billing tabs mounted at all times so their data-fetch effects run even when hidden
- Overlay the loading spinner instead of conditionally rendering the tabs so their effects always fire
- Memoize overview callbacks so child tabs don't refetch on every render
- Keep error boundary outside of OverviewTab function to stop the dialog from remounting and reloading repeatedly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e33dcb93c8323bc98688da1f5a968