### PR TITLE
Increase StudentDialog content padding

### DIFF
--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -33,7 +33,15 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             flexDirection: 'column',
           }}
         >
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              px: 6,
+              py: 1,
+            }}
+          >
             {title && (
               <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
                 {title}
@@ -46,7 +54,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 6 }}>{children}</Box>
         </Box>
       )
     }
@@ -77,7 +85,8 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
-              p: 1,
+              px: 6,
+              py: 1,
               borderBottom: 1,
               borderColor: 'divider',
               cursor: 'move',
@@ -95,7 +104,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 6 }}>{children}</Box>
         </Box>
       </Rnd>
     )

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -46,7 +46,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3 }}>{children}</Box>
         </Box>
       )
     }
@@ -95,7 +95,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3 }}>{children}</Box>
         </Box>
       </Rnd>
     )

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -38,7 +38,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
-              px: 6,
+              px: 5,
               py: 1,
             }}
           >
@@ -54,7 +54,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 6 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 5 }}>{children}</Box>
         </Box>
       )
     }
@@ -85,7 +85,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
-              px: 6,
+              px: 5,
               py: 1,
               borderBottom: 1,
               borderColor: 'divider',
@@ -104,7 +104,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 6 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 5 }}>{children}</Box>
         </Box>
       </Rnd>
     )

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -25,7 +25,7 @@ interface SessionDetailProps {
 export default function SessionDetail({ session, onBack }: SessionDetailProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
+      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3 }}>
         <Typography
           variant="subtitle2"
           sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -25,7 +25,7 @@ interface SessionDetailProps {
 export default function SessionDetail({ session, onBack }: SessionDetailProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3 }}>
+      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 6 }}>
         <Typography
           variant="subtitle2"
           sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -25,7 +25,7 @@ interface SessionDetailProps {
 export default function SessionDetail({ session, onBack }: SessionDetailProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 6 }}>
+      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 5 }}>
         <Typography
           variant="subtitle2"
           sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}


### PR DESCRIPTION
## Summary
- increase padding in floating window content area for mobile and desktop
- match SessionDetail content padding to new spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68931e70590883239ff1999ca0b27cac