### PR TITLE
Adjust student dialog floating window padding

### DIFF
--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -33,7 +33,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             flexDirection: 'column',
           }}
         >
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 6 }}>
             {title && (
               <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
                 {title}
@@ -46,7 +46,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 4 }}>{children}</Box>
         </Box>
       )
     }
@@ -77,7 +77,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
-              p: 1,
+              p: 6,
               borderBottom: 1,
               borderColor: 'divider',
               cursor: 'move',
@@ -95,7 +95,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>{children}</Box>
+          <Box sx={{ flexGrow: 1, overflow: 'auto', p: 4 }}>{children}</Box>
         </Box>
       </Rnd>
     )

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -33,7 +33,15 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             flexDirection: 'column',
           }}
         >
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 6 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              px: 6,
+              py: 1,
+            }}
+          >
             {title && (
               <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
                 {title}
@@ -77,7 +85,8 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
-              p: 6,
+              px: 6,
+              py: 1,
               borderBottom: 1,
               borderColor: 'divider',
               cursor: 'move',


### PR DESCRIPTION
## Summary
- expand floating window header padding to theme spacing 6
- expand floating window content padding to theme spacing 4

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939f6531f08323b1141efd55d20d0d