### PR TITLE
feat: payment assignment sub-tab and Nunito window titles

### DIFF
--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -43,7 +43,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             }}
           >
             {title && (
-              <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
+              <Typography variant="h6" sx={{ fontFamily: 'var(--font-nunito)' }}>
                 {title}
               </Typography>
             )}
@@ -93,7 +93,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             }}
           >
             {title && (
-              <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
+              <Typography variant="h6" sx={{ fontFamily: 'var(--font-nunito)' }}>
                 {title}
               </Typography>
             )}

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -186,6 +186,11 @@ export default function PaymentDetail({
               label={`${s.id} - ${
                 s.rate != null ? formatCurrency(Number(s.rate)) : '-'
               }`}
+              slotProps={{
+                typography: {
+                  sx: { fontFamily: 'Newsreader', fontWeight: 500 },
+                },
+              }}
             />
           ))}
         </FormGroup>

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -7,11 +7,32 @@ import {
   FormControlLabel,
   Checkbox,
 } from '@mui/material'
-import { collection, doc, getDocs, query, setDoc, updateDoc, where } from 'firebase/firestore'
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
+
+const formatDate = (d: Date | null) => {
+  if (!d) return 'N/A'
+  try {
+    return d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: '2-digit',
+      year: 'numeric',
+    })
+  } catch {
+    return 'N/A'
+  }
+}
 
 const displayField = (v: any) => {
   if (v === '__ERROR__') return 'Error'
@@ -51,33 +72,109 @@ export default function PaymentDetail({
     payment.remainingAmount ?? Number(payment.amount) ?? 0,
   )
 
+  const assignedSessions = sessions.filter((s) =>
+    s.paymentIds.includes(payment.id),
+  )
+  const availableSessions = sessions.filter((s) => s.paymentIds.length === 0)
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       try {
-        const snap = await getDocs(
-          query(collection(db, 'Sessions'), where('sessionName', '==', account)),
-        )
+        const [sessSnap, baseHistSnap, baseSnap] = await Promise.all([
+          getDocs(query(collection(db, 'Sessions'), where('sessionName', '==', account))),
+          getDocs(collection(db, 'Students', abbr, 'BaseRateHistory')),
+          getDocs(collection(db, 'Students', abbr, 'BaseRate')),
+        ])
+
+        const baseRates = [...baseHistSnap.docs, ...baseSnap.docs]
+          .map((d) => ({
+            rate: (d.data() as any).rate ?? (d.data() as any).baseRate,
+            ts:
+              (d.data() as any).timestamp?.toDate?.() ??
+              new Date((d.data() as any).timestamp || 0),
+          }))
+          .sort((a, b) => a.ts.getTime() - b.ts.getTime())
+
+        const parseDate = (v: any): Date | null => {
+          if (!v) return null
+          try {
+            const d = v.toDate ? v.toDate() : new Date(v)
+            return isNaN(d.getTime()) ? null : d
+          } catch {
+            return null
+          }
+        }
+
         const rows = await Promise.all(
-          snap.docs.map(async (sd) => {
-            const rateSnap = await getDocs(
-              collection(db, 'Sessions', sd.id, 'rateCharged'),
-            )
-            let rate: number | undefined
-            if (!rateSnap.empty) {
-              const sorted = rateSnap.docs
-                .map((d) => ({ ...(d.data() as any) }))
-                .sort((a, b) => {
-                  const ta = a.timestamp?.toDate?.() ?? new Date(0)
-                  const tb = b.timestamp?.toDate?.() ?? new Date(0)
-                  return tb.getTime() - ta.getTime()
-                })
-              rate = Number(sorted[0]?.rateCharged)
+          sessSnap.docs.map(async (sd) => {
+            const data = sd.data() as any
+            const [histSnap, rateSnap, paySnap] = await Promise.all([
+              getDocs(collection(db, 'Sessions', sd.id, 'appointmentHistory')),
+              getDocs(collection(db, 'Sessions', sd.id, 'rateCharged')),
+              getDocs(collection(db, 'Sessions', sd.id, 'payment')),
+            ])
+
+            const hist = histSnap.docs
+              .map((d) => ({ ...(d.data() as any) }))
+              .sort((a, b) => {
+                const ta =
+                  parseDate(a.changeTimestamp) ||
+                  parseDate(a.timestamp) ||
+                  new Date(0)
+                const tb =
+                  parseDate(b.changeTimestamp) ||
+                  parseDate(b.timestamp) ||
+                  new Date(0)
+                return tb.getTime() - ta.getTime()
+              })[0]
+
+            const startRaw =
+              hist?.newStartTimestamp != null
+                ? hist.newStartTimestamp
+                : hist?.origStartTimestamp ?? hist?.timestamp
+            const startDate = parseDate(startRaw)
+
+            const base = (() => {
+              if (!startDate || !baseRates.length) return 0
+              const entry = baseRates
+                .filter((b) => b.ts.getTime() <= startDate.getTime())
+                .pop()
+              return entry ? Number(entry.rate) : 0
+            })()
+
+            const rateHist = rateSnap.docs
+              .map((d) => ({ ...(d.data() as any) }))
+              .sort((a, b) => {
+                const ta = parseDate(a.timestamp) || new Date(0)
+                const tb = parseDate(b.timestamp) || new Date(0)
+                return tb.getTime() - ta.getTime()
+              })
+            const latestRate = rateHist[0]?.rateCharged
+            const rate = latestRate != null ? Number(latestRate) : base
+
+            const paymentIds = paySnap.docs.map((d) => d.id)
+
+            return {
+              id: sd.id,
+              sessionType: data.sessionType ?? 'N/A',
+              startDate,
+              rate,
+              paymentIds,
             }
-            return { id: sd.id, rate }
           }),
         )
-        if (!cancelled) setSessions(rows)
+
+        const sorted = rows
+          .slice()
+          .sort((a, b) => {
+            const ta = a.startDate ? a.startDate.getTime() : 0
+            const tb = b.startDate ? b.startDate.getTime() : 0
+            return ta - tb
+          })
+          .map((r, i) => ({ ...r, count: i + 1 }))
+
+        if (!cancelled) setSessions(sorted)
       } catch (e) {
         console.error('load sessions failed', e)
         if (!cancelled) setSessions([])
@@ -122,6 +219,13 @@ export default function PaymentDetail({
       })
       payment.assignedSessions = newAssigned
       setRemaining(newRemaining)
+      setSessions((prev) =>
+        prev.map((s) =>
+          selected.includes(s.id)
+            ? { ...s, paymentIds: [...s.paymentIds, payment.id] }
+            : s,
+        ),
+      )
       setSelected([])
     } catch (e) {
       console.error('assign payment failed', e)
@@ -167,33 +271,40 @@ export default function PaymentDetail({
         >
           Payment for:
         </Typography>
-        <FormGroup>
-          {sessions.map((s) => (
-            <FormControlLabel
-              key={s.id}
-              control={
-                <Checkbox
-                  checked={selected.includes(s.id)}
-                  onChange={() => toggle(s.id)}
-                  disabled={
-                    assigning ||
-                    remaining <= 0 ||
-                    (payment.assignedSessions || []).includes(s.id) ||
-                    (s.rate || 0) > remaining
-                  }
-                />
-              }
-              label={`${s.id} - ${
-                s.rate != null ? formatCurrency(Number(s.rate)) : '-'
-              }`}
-              slotProps={{
-                typography: {
-                  sx: { fontFamily: 'Newsreader', fontWeight: 500 },
-                },
-              }}
-            />
-          ))}
-        </FormGroup>
+        {assignedSessions.map((s) => (
+          <Typography
+            key={s.id}
+            variant="h6"
+            sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          >
+            {`${s.count} | ${formatDate(s.startDate)} (${s.sessionType})`}
+          </Typography>
+        ))}
+        {remaining > 0 && (
+          <FormGroup>
+            {availableSessions.map((s) => (
+              <FormControlLabel
+                key={s.id}
+                control={
+                  <Checkbox
+                    checked={selected.includes(s.id)}
+                    onChange={() => toggle(s.id)}
+                    disabled={
+                      assigning ||
+                      (s.rate || 0) > remaining
+                    }
+                  />
+                }
+                label={`${s.count} | ${formatDate(s.startDate)} (${s.sessionType})`}
+                slotProps={{
+                  typography: {
+                    sx: { fontFamily: 'Newsreader', fontWeight: 500 },
+                  },
+                }}
+              />
+            ))}
+          </FormGroup>
+        )}
         <Button
           variant="contained"
           sx={{ mt: 1 }}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import { SessionProvider, useSession } from 'next-auth/react';
 import { SnackbarProvider } from 'notistack';
 import type { AppProps } from 'next/app';
 import { setupClientLogging } from '../lib/clientLogger';
-import { Newsreader, Cantata_One } from 'next/font/google';
+import { Newsreader, Cantata_One, Nunito } from 'next/font/google';
 
 if (typeof window !== 'undefined') {
   setupClientLogging();
@@ -13,10 +13,11 @@ const newsreader = Newsreader({ subsets: ['latin'], weight: ['200', '500'] });
 // Cantata One exposes only a regular 400 weight, so we must specify it
 // explicitly to satisfy the Next.js font loader typings.
 const cantata = Cantata_One({ subsets: ['latin'], weight: '400' });
+const nunito = Nunito({ subsets: ['latin'], weight: '400', variable: '--font-nunito' });
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${newsreader.className} ${cantata.className}`}>
+    <div className={`${newsreader.className} ${cantata.className} ${nunito.variable}`}>
       <SessionProvider session={pageProps.session}>
         <SnackbarProvider maxSnack={3}>
           <Component {...pageProps} />


### PR DESCRIPTION
## Summary
- add Payment History sub-tab listing student payments
- allow assigning payment amounts to sessions from payment detail view
- switch floating window titles to Nunito font

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689438b338048323a63308c436d22524