### PR TITLE
feat: manage retainers with subcollection and validation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -32,5 +32,6 @@ The most recent reload loop traced to defining the error boundary inside `Overvi
 
 Floating windows later became immovable when a `onMouseDown` handler on the header stopped drag events from reaching `react-rnd`. Removing that handler restored independent window movement.
 
-* All date displays in the web app should use MMM DD, YYYY format unless otherwise specified.
+* All date displays in the web app use MMM DD, YYYY format.
 * Section and table headings use Cantata One font; table row content uses Newsreader font at weight 500.
+* All modals must provide a Back/Close navigation consistent with the Session Detail modal.

--- a/AGENT.md
+++ b/AGENT.md
@@ -35,3 +35,4 @@ Floating windows later became immovable when a `onMouseDown` handler on the head
 * All date displays in the web app use MMM DD, YYYY format.
 * Section and table headings use Cantata One font; table row content uses Newsreader font at weight 500.
 * All modals must provide a Back/Close navigation consistent with the Session Detail modal.
+* Tab and sub-tab navigation lives in the dialog sidebar. Sub-tabs expand beneath their parent tab and must not appear in top bars or popovers.

--- a/AGENT.md
+++ b/AGENT.md
@@ -35,5 +35,5 @@ Floating windows later became immovable when a `onMouseDown` handler on the head
 * All date displays in the web app use MMM DD, YYYY format.
 * Section and table headings use Cantata One font; table row content uses Newsreader font at weight 500.
 * All modals must provide a Back/Close navigation consistent with the Session Detail modal.
-* Tab and sub-tab navigation lives in the dialog sidebar. Sub-tabs expand beneath their parent tab and must not appear in top bars or popovers.
+* Tab and sub-tab navigation lives in the dialog sidebar. The Billing parent tab shows the summary; its only child sub-tabs are Retainers and Payment History. Sub-tabs must not appear in top bars or popovers.
 * Retainer status colors: green for active, red for expiring/expired, lightBlue for upcoming, and lightGreen when an expired retainer has a future one scheduled.

--- a/AGENT.md
+++ b/AGENT.md
@@ -37,3 +37,6 @@ Floating windows later became immovable when a `onMouseDown` handler on the head
 * All modals must provide a Back/Close navigation consistent with the Session Detail modal.
 * Tab and sub-tab navigation lives in the dialog sidebar. The Billing parent tab shows the summary; its only child sub-tabs are Retainers and Payment History. Sub-tabs must not appear in top bars or popovers.
 * Retainer status colors: green for active, red for expiring/expired, lightBlue for upcoming, and lightGreen when an expired retainer has a future one scheduled.
+* Floating window titles use Nunito.
+* Selected Payment Detail shows curated labels: Payment Amount, Payment Made On (date only), For session.
+* Retainer end date is the day before the same day next month (end at 23:59:59).

--- a/AGENT.md
+++ b/AGENT.md
@@ -36,3 +36,4 @@ Floating windows later became immovable when a `onMouseDown` handler on the head
 * Section and table headings use Cantata One font; table row content uses Newsreader font at weight 500.
 * All modals must provide a Back/Close navigation consistent with the Session Detail modal.
 * Tab and sub-tab navigation lives in the dialog sidebar. Sub-tabs expand beneath their parent tab and must not appear in top bars or popovers.
+* Retainer status colors: green for active, red for expiring/expired, lightBlue for upcoming, and lightGreen when an expired retainer has a future one scheduled.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,26 @@ Field numbers are:
 | B1     | billingCompany |
 | B2     | defaultBillingType |
 | B3     | baseRate |
-| B4     | retainerStatus |
 | B5     | lastPaymentDate |
 | B6     | balanceDue |
 | B7     | voucherBalance |
 
 Each document stores only the edited value and a `timestamp` so the full history
 can be tracked.
+
+### Retainers
+
+Each student has a `Retainers` subcollection storing individual retainer
+documents with the following fields:
+
+- `retainerStarts` (Timestamp)
+- `retainerEnds` (Timestamp)
+- `retainerRate` (Number)
+- `timestamp` (Timestamp)
+- `editedBy` (String)
+
+Document IDs follow the same `<abbr>-RT-<index>-<YYYYMMDD>` scheme used by
+other history records.
 
 ## Placeholder Display
 

--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -54,7 +54,6 @@ export default function InlineEdit({
         billingCompany: 'B1',
         defaultBillingType: 'B2',
         baseRate: 'B3',
-        retainerStatus: 'B4',
         lastPaymentDate: 'B5',
         balanceDue: 'B6',
         voucherBalance: 'B7',

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -1,11 +1,12 @@
 // components/StudentDialog/BillingTab.tsx
 
 import React, { useEffect, useState } from 'react'
-import { Box, Typography } from '@mui/material'
+import { Box, Typography, Tabs, Tab } from '@mui/material'
 import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 import InlineEdit from '../../common/InlineEdit'
 import { getLatestRetainer } from '../../lib/retainer'
+import RetainersTab from './RetainersTab'
 
 console.log('=== StudentDialog loaded version 1.1 ===')
 
@@ -61,6 +62,7 @@ export default function BillingTab({
     balanceDue: true,
     voucherBalance: true,
   })
+  const [sub, setSub] = useState(0)
 
   const loadLatest = async (sub: string, field: string, orderField = 'timestamp') => {
     try {
@@ -348,32 +350,47 @@ export default function BillingTab({
         flexDirection: 'column',
       }}
     >
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>
-        <Typography
-          variant="subtitle1"
-          sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
-        >
-          Billing Information
-        </Typography>
-        {[
-          'balanceDue',
-          'baseRate',
-          'retainer',
-          'lastPaymentDate',
-          'voucherBalance',
-        ].map((k) => renderField(k))}
-        <Typography
-          variant="subtitle1"
-          sx={{
-            fontFamily: 'Cantata One',
-            textDecoration: 'underline',
-            mt: 2,
-          }}
-        >
-          Payment Information
-        </Typography>
-        {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
-      </Box>
+      <Tabs
+        value={sub}
+        onChange={(_, v) => setSub(v)}
+        sx={{ borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label="Billing Info" sx={{ fontFamily: 'Cantata One' }} />
+        <Tab label="Retainers" sx={{ fontFamily: 'Cantata One' }} />
+      </Tabs>
+      {sub === 0 ? (
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>
+          <Typography
+            variant="subtitle1"
+            sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
+          >
+            Billing Information
+          </Typography>
+          {[
+            'balanceDue',
+            'baseRate',
+            'retainer',
+            'lastPaymentDate',
+            'voucherBalance',
+          ].map((k) => renderField(k))}
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontFamily: 'Cantata One',
+              textDecoration: 'underline',
+              mt: 2,
+            }}
+          >
+            Payment Information
+          </Typography>
+          {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
+        </Box>
+      ) : (
+        <RetainersTab
+          abbr={abbr}
+          balanceDue={Number(fields.balanceDue) || 0}
+        />
+      )}
     </Box>
   )
 }

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -1,11 +1,10 @@
 // components/StudentDialog/BillingTab.tsx
 
 import React, { useEffect, useState } from 'react'
-import { Box, Typography, Tabs, Tab } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 import InlineEdit from '../../common/InlineEdit'
-import PaymentHistory from './PaymentHistory'
 import { getLatestRetainer } from '../../lib/retainer'
 
 console.log('=== StudentDialog loaded version 1.1 ===')
@@ -62,7 +61,6 @@ export default function BillingTab({
     balanceDue: true,
     voucherBalance: true,
   })
-  const [tab, setTab] = useState(0)
 
   const loadLatest = async (sub: string, field: string, orderField = 'timestamp') => {
     try {
@@ -350,41 +348,31 @@ export default function BillingTab({
         flexDirection: 'column',
       }}
     >
-      <Tabs value={tab} onChange={(_, v) => setTab(v)}>
-        <Tab label="Summary" />
-        <Tab label="Payment History" />
-      </Tabs>
       <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>
-        {tab === 0 ? (
-          <>
-            <Typography
-              variant="subtitle1"
-              sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
-            >
-              Billing Information
-            </Typography>
-            {[
-              'balanceDue',
-              'baseRate',
-              'retainer',
-              'lastPaymentDate',
-              'voucherBalance',
-            ].map((k) => renderField(k))}
-            <Typography
-              variant="subtitle1"
-              sx={{
-                fontFamily: 'Cantata One',
-                textDecoration: 'underline',
-                mt: 2,
-              }}
-            >
-              Payment Information
-            </Typography>
-            {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
-          </>
-        ) : (
-          <PaymentHistory abbr={abbr} account={account} />
-        )}
+        <Typography
+          variant="subtitle1"
+          sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
+        >
+          Billing Information
+        </Typography>
+        {[
+          'balanceDue',
+          'baseRate',
+          'retainer',
+          'lastPaymentDate',
+          'voucherBalance',
+        ].map((k) => renderField(k))}
+        <Typography
+          variant="subtitle1"
+          sx={{
+            fontFamily: 'Cantata One',
+            textDecoration: 'underline',
+            mt: 2,
+          }}
+        >
+          Payment Information
+        </Typography>
+        {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
       </Box>
     </Box>
   )

--- a/components/StudentDialog/BillingTab.tsx
+++ b/components/StudentDialog/BillingTab.tsx
@@ -1,12 +1,11 @@
 // components/StudentDialog/BillingTab.tsx
 
 import React, { useEffect, useState } from 'react'
-import { Box, Typography, Tabs, Tab } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 import InlineEdit from '../../common/InlineEdit'
 import { getLatestRetainer } from '../../lib/retainer'
-import RetainersTab from './RetainersTab'
 
 console.log('=== StudentDialog loaded version 1.1 ===')
 
@@ -62,7 +61,6 @@ export default function BillingTab({
     balanceDue: true,
     voucherBalance: true,
   })
-  const [sub, setSub] = useState(0)
 
   const loadLatest = async (sub: string, field: string, orderField = 'timestamp') => {
     try {
@@ -350,47 +348,32 @@ export default function BillingTab({
         flexDirection: 'column',
       }}
     >
-      <Tabs
-        value={sub}
-        onChange={(_, v) => setSub(v)}
-        sx={{ borderBottom: 1, borderColor: 'divider' }}
-      >
-        <Tab label="Billing Info" sx={{ fontFamily: 'Cantata One' }} />
-        <Tab label="Retainers" sx={{ fontFamily: 'Cantata One' }} />
-      </Tabs>
-      {sub === 0 ? (
-        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>
-          <Typography
-            variant="subtitle1"
-            sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
-          >
-            Billing Information
-          </Typography>
-          {[
-            'balanceDue',
-            'baseRate',
-            'retainer',
-            'lastPaymentDate',
-            'voucherBalance',
-          ].map((k) => renderField(k))}
-          <Typography
-            variant="subtitle1"
-            sx={{
-              fontFamily: 'Cantata One',
-              textDecoration: 'underline',
-              mt: 2,
-            }}
-          >
-            Payment Information
-          </Typography>
-          {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
-        </Box>
-      ) : (
-        <RetainersTab
-          abbr={abbr}
-          balanceDue={Number(fields.balanceDue) || 0}
-        />
-      )}
+      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1 }}>
+        <Typography
+          variant="subtitle1"
+          sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
+        >
+          Billing Information
+        </Typography>
+        {[
+          'balanceDue',
+          'baseRate',
+          'retainer',
+          'lastPaymentDate',
+          'voucherBalance',
+        ].map((k) => renderField(k))}
+        <Typography
+          variant="subtitle1"
+          sx={{
+            fontFamily: 'Cantata One',
+            textDecoration: 'underline',
+            mt: 2,
+          }}
+        >
+          Payment Information
+        </Typography>
+        {['defaultBillingType', 'billingCompany'].map((k) => renderField(k))}
+      </Box>
     </Box>
   )
 }

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -43,7 +43,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             }}
           >
             {title && (
-              <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
+              <Typography variant="h6" className="floating-title">
                 {title}
               </Typography>
             )}
@@ -93,7 +93,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             }}
           >
             {title && (
-              <Typography variant="h6" sx={{ fontFamily: 'Cantata One' }}>
+              <Typography variant="h6" className="floating-title">
                 {title}
               </Typography>
             )}

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -127,6 +127,12 @@ export default function OverviewTab({
 
   const handleTabChange = (_: any, v: string) => selectTab(v)
 
+  const closeAndReset = () => {
+    setTab('overview')
+    setTitle(account)
+    onClose()
+  }
+
   // reset loading states whenever dialog is opened
   useEffect(() => {
     console.log('OverviewTab reset effect for', abbr)
@@ -138,23 +144,10 @@ export default function OverviewTab({
       setBillingLoading({ balanceDue: true, voucherBalance: true })
       setOverviewLoading(true)
       setActions(null)
-      if (typeof window !== 'undefined') {
-        const params = new URLSearchParams(window.location.search)
-        const q = params.get('tab')
-        selectTab(q || 'overview')
-      } else {
-        selectTab('overview')
-      }
+      setTab('overview')
+      setTitle(account)
     }
   }, [open, abbr, account])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const params = new URLSearchParams(window.location.search)
-    params.set('tab', tab)
-    const url = `${window.location.pathname}?${params.toString()}`
-    window.history.replaceState(null, '', url)
-  }, [tab])
 
   useEffect(() => {
     console.log('OverviewTab loading states', {
@@ -178,7 +171,7 @@ export default function OverviewTab({
   if (!open) return null
   return (
     <StudentDialogErrorBoundary>
-      <FloatingWindow onClose={onClose} title={title} actions={actions}>
+      <FloatingWindow onClose={closeAndReset} title={title} actions={actions}>
         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%', maxHeight: '100%', maxWidth: '100%', overflow: 'hidden' }}>
           <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative', alignItems: 'flex-start', maxHeight: '100%', maxWidth: '100%' }}>
             {loading && (
@@ -416,65 +409,40 @@ export default function OverviewTab({
               <Tab
                 value="billing"
                 label="Billing"
+                onClick={() => selectTab('billing')}
                 sx={{
                   textAlign: 'right',
                   justifyContent: 'flex-end',
                   width: '100%',
                   bgcolor: tab.startsWith('billing') ? 'action.selected' : undefined,
                 }}
-                onClick={() => selectTab('billing')}
               />
-              <Box
+              <Tab
+                value="billing-retainers"
+                label="Retainers"
                 sx={{
                   display: tab.startsWith('billing') ? 'flex' : 'none',
-                  flexDirection: 'column',
+                  pl: 4,
+                  fontSize: '0.82rem',
+                  textAlign: 'right',
+                  justifyContent: 'flex-end',
                   width: '100%',
-                  pr: 0,
-                  pl: 0,
                 }}
-              >
-                <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
-                  <Box
-                    sx={{
-                      width: '100%',
-                      maxWidth: 160,
-                      borderLeft: 2,
-                      borderColor: 'divider',
-                      ml: 'auto',
-                      pr: 0,
-                    }}
-                  >
-                    <Tab
-                      value="billing-retainers"
-                      label="Retainers"
-                      sx={{
-                        pl: 4,
-                        fontSize: '0.82rem',
-                        color: 'text.secondary',
-                        '&.Mui-selected': { color: 'text.primary', fontWeight: 600 },
-                        textAlign: 'right',
-                        justifyContent: 'flex-end',
-                        width: '100%',
-                      }}
-                      onClick={() => selectTab('billing-retainers')}
-                    />
-                    <Tab
-                      value="billing-history"
-                      label="Payment History"
-                      sx={{
-                        pl: 4,
-                        fontSize: '0.82rem',
-                        color: 'text.secondary',
-                        '&.Mui-selected': { color: 'text.primary', fontWeight: 600 },
-                        textAlign: 'right',
-                        justifyContent: 'flex-end',
-                        width: '100%',
-                      }}
-                      onClick={() => selectTab('billing-history')}
-                    />
-                  </Box>
-                </Box>
-              </Box>
+                onClick={() => selectTab('billing-retainers')}
+              />
+              <Tab
+                value="billing-history"
+                label="Payment History"
+                sx={{
+                  display: tab.startsWith('billing') ? 'flex' : 'none',
+                  pl: 4,
+                  fontSize: '0.82rem',
+                  textAlign: 'right',
+                  justifyContent: 'flex-end',
+                  width: '100%',
+                }}
+                onClick={() => selectTab('billing-history')}
+              />
             </Tabs>
           </Box>
         </Box>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -1,7 +1,7 @@
 // components/StudentDialog/OverviewTab.tsx
 
 import React, { useEffect, useState, useCallback } from 'react'
-import { Tabs, Tab, Box, CircularProgress, Typography, Button } from '@mui/material'
+import { Tabs, Tab, Box, CircularProgress, Typography } from '@mui/material'
 import FloatingWindow from './FloatingWindow'
 
 // OverviewTab acts purely as a presenter. PersonalTab, SessionsTab and
@@ -112,13 +112,7 @@ export default function OverviewTab({
     [setOverview, setOverviewLoading],
   )
 
-  const handleTabChange = (_: any, v: string) => {
-    if (v === 'billing') {
-      setTab('billing-info')
-    } else {
-      setTab(v)
-    }
-  }
+  const handleTabChange = (_: any, v: string) => setTab(v)
 
   // reset loading states whenever dialog is opened
   useEffect(() => {
@@ -130,11 +124,25 @@ export default function OverviewTab({
       setPersonalLoading({ firstName: true, lastName: true, sex: true })
       setBillingLoading({ balanceDue: true, voucherBalance: true })
       setOverviewLoading(true)
-      setTab('overview')
       setTitle(account)
       setActions(null)
+      if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search)
+        const q = params.get('tab')
+        setTab(q || 'overview')
+      } else {
+        setTab('overview')
+      }
     }
-  }, [open])
+  }, [open, abbr, account])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    params.set('tab', tab)
+    const url = `${window.location.pathname}?${params.toString()}`
+    window.history.replaceState(null, '', url)
+  }, [tab])
 
   useEffect(() => {
     console.log('OverviewTab loading states', {
@@ -347,7 +355,7 @@ export default function OverviewTab({
                 account={account}
                 serviceMode={serviceMode}
                 onBilling={handleBilling}
-                style={{ display: tab === 'billing-info' ? 'block' : 'none' }}
+                style={{ display: tab === 'billing' ? 'block' : 'none' }}
               />
               <Box sx={{ display: tab === 'billing-retainers' ? 'block' : 'none' }}>
                 <RetainersTab
@@ -396,26 +404,36 @@ export default function OverviewTab({
                   width: '100%',
                   bgcolor: tab.startsWith('billing') ? 'action.selected' : undefined,
                 }}
+                onClick={() => setTab('billing')}
               />
-              {tab.startsWith('billing') && (
-                <>
-                  <Tab
-                    value="billing-info"
-                    label="Billing Info"
-                    sx={{ pl: 2, textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
-                  />
-                  <Tab
-                    value="billing-retainers"
-                    label="Retainers"
-                    sx={{ pl: 2, textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
-                  />
-                  <Tab
-                    value="billing-history"
-                    label="Payment History"
-                    sx={{ pl: 2, textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
-                  />
-                </>
-              )}
+              <Tab
+                value="billing-retainers"
+                label="Retainers"
+                sx={{
+                  pl: 4,
+                  fontSize: '0.85rem',
+                  color: 'text.secondary',
+                  textAlign: 'right',
+                  justifyContent: 'flex-end',
+                  width: '100%',
+                  display: tab.startsWith('billing') ? 'flex' : 'none',
+                }}
+                onClick={() => setTab('billing-retainers')}
+              />
+              <Tab
+                value="billing-history"
+                label="Payment History"
+                sx={{
+                  pl: 4,
+                  fontSize: '0.85rem',
+                  color: 'text.secondary',
+                  textAlign: 'right',
+                  justifyContent: 'flex-end',
+                  width: '100%',
+                  display: tab.startsWith('billing') ? 'flex' : 'none',
+                }}
+                onClick={() => setTab('billing-history')}
+              />
             </Tabs>
           </Box>
         </Box>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -11,6 +11,7 @@ import FloatingWindow from './FloatingWindow'
 // OverviewTab never queries Firestore directly.
 import PersonalTab from './PersonalTab'
 import BillingTab from './BillingTab'
+import RetainersTab from './RetainersTab'
 import SessionsTab from './SessionsTab'
 import PaymentHistory from './PaymentHistory'
 
@@ -60,7 +61,7 @@ export default function OverviewTab({
   onPopDetail,
 }: OverviewTabProps) {
   console.log('OverviewTab rendered for', abbr)
-  const [tab, setTab] = useState(0)
+  const [tab, setTab] = useState<string>('overview')
   const [title, setTitle] = useState(account)
   const [actions, setActions] = useState<React.ReactNode | null>(null)
 
@@ -111,6 +112,14 @@ export default function OverviewTab({
     [setOverview, setOverviewLoading],
   )
 
+  const handleTabChange = (_: any, v: string) => {
+    if (v === 'billing') {
+      setTab('billing-info')
+    } else {
+      setTab(v)
+    }
+  }
+
   // reset loading states whenever dialog is opened
   useEffect(() => {
     console.log('OverviewTab reset effect for', abbr)
@@ -121,7 +130,7 @@ export default function OverviewTab({
       setPersonalLoading({ firstName: true, lastName: true, sex: true })
       setBillingLoading({ balanceDue: true, voucherBalance: true })
       setOverviewLoading(true)
-      setTab(0)
+      setTab('overview')
       setTitle(account)
       setActions(null)
     }
@@ -179,7 +188,7 @@ export default function OverviewTab({
                 maxWidth: '100%',
               }}
             >
-              <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
+              <Box sx={{ display: tab === 'overview' ? 'block' : 'none' }}>
                 <Typography
                   variant="subtitle2"
                   sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
@@ -320,7 +329,7 @@ export default function OverviewTab({
                 abbr={abbr}
                 serviceMode={serviceMode}
                 onPersonal={handlePersonal}
-                style={{ display: tab === 1 ? 'block' : 'none' }}
+                style={{ display: tab === 'personal' ? 'block' : 'none' }}
               />
 
               <SessionsTab
@@ -330,7 +339,7 @@ export default function OverviewTab({
                 onTitle={setTitle}
                 onActions={setActions}
                 onPopDetail={onPopDetail}
-                style={{ display: tab === 2 ? 'block' : 'none' }}
+                style={{ display: tab === 'sessions' ? 'block' : 'none' }}
               />
 
               <BillingTab
@@ -338,9 +347,15 @@ export default function OverviewTab({
                 account={account}
                 serviceMode={serviceMode}
                 onBilling={handleBilling}
-                style={{ display: tab === 3 ? 'block' : 'none' }}
+                style={{ display: tab === 'billing-info' ? 'block' : 'none' }}
               />
-              <Box sx={{ display: tab === 4 ? 'block' : 'none' }}>
+              <Box sx={{ display: tab === 'billing-retainers' ? 'block' : 'none' }}>
+                <RetainersTab
+                  abbr={abbr}
+                  balanceDue={Number(billing.balanceDue) || 0}
+                />
+              </Box>
+              <Box sx={{ display: tab === 'billing-history' ? 'block' : 'none' }}>
                 <PaymentHistory abbr={abbr} account={account} />
               </Box>
             </Box>
@@ -348,7 +363,7 @@ export default function OverviewTab({
             <Tabs
               orientation="vertical"
               value={tab}
-              onChange={(_, v) => setTab(v)}
+              onChange={handleTabChange}
               sx={{
                 borderLeft: 1,
                 borderColor: 'divider',
@@ -357,18 +372,46 @@ export default function OverviewTab({
                 display: loading ? 'none' : 'flex',
               }}
             >
-              {['Overview', 'Personal', 'Sessions', 'Billing', 'Payment History'].map((l) => (
-                <Tab
-                  key={l}
-                  label={l}
-                  sx={{
-                    textAlign: 'right',
-                    justifyContent: 'flex-end',
-                    alignItems: 'flex-end',
-                    width: '100%',
-                  }}
-                />
-              ))}
+              <Tab
+                value="overview"
+                label="Overview"
+                sx={{ textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+              />
+              <Tab
+                value="personal"
+                label="Personal"
+                sx={{ textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+              />
+              <Tab
+                value="sessions"
+                label="Sessions"
+                sx={{ textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+              />
+              <Tab
+                value="billing"
+                label="Billing"
+                selected={tab.startsWith('billing')}
+                sx={{ textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+              />
+              {tab.startsWith('billing') && (
+                <>
+                  <Tab
+                    value="billing-info"
+                    label="Billing Info"
+                    sx={{ pl: 2, textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+                  />
+                  <Tab
+                    value="billing-retainers"
+                    label="Retainers"
+                    sx={{ pl: 2, textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+                  />
+                  <Tab
+                    value="billing-history"
+                    label="Payment History"
+                    sx={{ pl: 2, textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+                  />
+                </>
+              )}
             </Tabs>
           </Box>
         </Box>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -112,7 +112,20 @@ export default function OverviewTab({
     [setOverview, setOverviewLoading],
   )
 
-  const handleTabChange = (_: any, v: string) => setTab(v)
+  const selectTab = (v: string) => {
+    setTab(v)
+    if (v === 'billing-retainers')
+      setTitle(`${account} - Billing - Retainers`)
+    else if (v === 'billing-history')
+      setTitle(`${account} - Billing - Payment History`)
+    else if (v === 'billing') setTitle(`${account} - Billing`)
+    else
+      setTitle(
+        `${account} - ${v.charAt(0).toUpperCase() + v.slice(1)}`,
+      )
+  }
+
+  const handleTabChange = (_: any, v: string) => selectTab(v)
 
   // reset loading states whenever dialog is opened
   useEffect(() => {
@@ -124,14 +137,13 @@ export default function OverviewTab({
       setPersonalLoading({ firstName: true, lastName: true, sex: true })
       setBillingLoading({ balanceDue: true, voucherBalance: true })
       setOverviewLoading(true)
-      setTitle(account)
       setActions(null)
       if (typeof window !== 'undefined') {
         const params = new URLSearchParams(window.location.search)
         const q = params.get('tab')
-        setTab(q || 'overview')
+        selectTab(q || 'overview')
       } else {
-        setTab('overview')
+        selectTab('overview')
       }
     }
   }, [open, abbr, account])
@@ -361,10 +373,16 @@ export default function OverviewTab({
                 <RetainersTab
                   abbr={abbr}
                   balanceDue={Number(billing.balanceDue) || 0}
+                  account={account}
+                  onTitleChange={(t) => setTitle(t)}
                 />
               </Box>
               <Box sx={{ display: tab === 'billing-history' ? 'block' : 'none' }}>
-                <PaymentHistory abbr={abbr} account={account} />
+                <PaymentHistory
+                  abbr={abbr}
+                  account={account}
+                  onTitleChange={(t) => setTitle(t)}
+                />
               </Box>
             </Box>
 
@@ -404,36 +422,59 @@ export default function OverviewTab({
                   width: '100%',
                   bgcolor: tab.startsWith('billing') ? 'action.selected' : undefined,
                 }}
-                onClick={() => setTab('billing')}
+                onClick={() => selectTab('billing')}
               />
-              <Tab
-                value="billing-retainers"
-                label="Retainers"
+              <Box
                 sx={{
-                  pl: 4,
-                  fontSize: '0.85rem',
-                  color: 'text.secondary',
-                  textAlign: 'right',
-                  justifyContent: 'flex-end',
-                  width: '100%',
                   display: tab.startsWith('billing') ? 'flex' : 'none',
-                }}
-                onClick={() => setTab('billing-retainers')}
-              />
-              <Tab
-                value="billing-history"
-                label="Payment History"
-                sx={{
-                  pl: 4,
-                  fontSize: '0.85rem',
-                  color: 'text.secondary',
-                  textAlign: 'right',
-                  justifyContent: 'flex-end',
+                  flexDirection: 'column',
                   width: '100%',
-                  display: tab.startsWith('billing') ? 'flex' : 'none',
+                  pr: 0,
+                  pl: 0,
                 }}
-                onClick={() => setTab('billing-history')}
-              />
+              >
+                <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
+                  <Box
+                    sx={{
+                      width: '100%',
+                      maxWidth: 160,
+                      borderLeft: 2,
+                      borderColor: 'divider',
+                      ml: 'auto',
+                      pr: 0,
+                    }}
+                  >
+                    <Tab
+                      value="billing-retainers"
+                      label="Retainers"
+                      sx={{
+                        pl: 4,
+                        fontSize: '0.82rem',
+                        color: 'text.secondary',
+                        '&.Mui-selected': { color: 'text.primary', fontWeight: 600 },
+                        textAlign: 'right',
+                        justifyContent: 'flex-end',
+                        width: '100%',
+                      }}
+                      onClick={() => selectTab('billing-retainers')}
+                    />
+                    <Tab
+                      value="billing-history"
+                      label="Payment History"
+                      sx={{
+                        pl: 4,
+                        fontSize: '0.82rem',
+                        color: 'text.secondary',
+                        '&.Mui-selected': { color: 'text.primary', fontWeight: 600 },
+                        textAlign: 'right',
+                        justifyContent: 'flex-end',
+                        width: '100%',
+                      }}
+                      onClick={() => selectTab('billing-history')}
+                    />
+                  </Box>
+                </Box>
+              </Box>
             </Tabs>
           </Box>
         </Box>

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -12,6 +12,7 @@ import FloatingWindow from './FloatingWindow'
 import PersonalTab from './PersonalTab'
 import BillingTab from './BillingTab'
 import SessionsTab from './SessionsTab'
+import PaymentHistory from './PaymentHistory'
 
 console.log('=== StudentDialog loaded version 1.1 ===')
 
@@ -339,6 +340,9 @@ export default function OverviewTab({
                 onBilling={handleBilling}
                 style={{ display: tab === 3 ? 'block' : 'none' }}
               />
+              <Box sx={{ display: tab === 4 ? 'block' : 'none' }}>
+                <PaymentHistory abbr={abbr} account={account} />
+              </Box>
             </Box>
 
             <Tabs
@@ -353,7 +357,7 @@ export default function OverviewTab({
                 display: loading ? 'none' : 'flex',
               }}
             >
-              {['Overview', 'Personal', 'Sessions', 'Billing'].map((l) => (
+              {['Overview', 'Personal', 'Sessions', 'Billing', 'Payment History'].map((l) => (
                 <Tab
                   key={l}
                   label={l}

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -390,8 +390,12 @@ export default function OverviewTab({
               <Tab
                 value="billing"
                 label="Billing"
-                selected={tab.startsWith('billing')}
-                sx={{ textAlign: 'right', justifyContent: 'flex-end', width: '100%' }}
+                sx={{
+                  textAlign: 'right',
+                  justifyContent: 'flex-end',
+                  width: '100%',
+                  bgcolor: tab.startsWith('billing') ? 'action.selected' : undefined,
+                }}
               />
               {tab.startsWith('billing') && (
                 <>

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -119,6 +119,13 @@ export default function PaymentDetail({
                     day: '2-digit',
                     year: 'numeric',
                   })
+            const time =
+              !startDate || isNaN(startDate.getTime())
+                ? '-'
+                : startDate.toLocaleTimeString('en-US', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })
 
             const base = (() => {
               if (!startDate || !baseRates.length) return 0
@@ -150,8 +157,8 @@ export default function PaymentDetail({
 
             return {
               id: sd.id,
-              sessionType: data.sessionType ?? 'N/A',
               date,
+              time,
               rate,
               assigned,
               assignedToOther,
@@ -264,19 +271,19 @@ export default function PaymentDetail({
         >
           Pay for:
         </Typography>
-        {assignedSessions.map((s) => (
+        {assignedSessions.map((s, i) => (
           <Typography
             key={s.id}
             variant="h6"
             sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
           >
-            {`${s.id} | ${s.date} (${s.sessionType})`}
+            {`${i + 1} | ${s.date} | ${s.time}`}
           </Typography>
         ))}
         {remaining > 0 && (
           <>
             <FormGroup>
-              {available.map((s) => (
+              {available.map((s, i) => (
                 <FormControlLabel
                   key={s.id}
                   control={
@@ -286,7 +293,7 @@ export default function PaymentDetail({
                       disabled={assigning || (s.rate || 0) > remaining}
                     />
                   }
-                  label={`${s.id} | ${s.date} (${s.sessionType})`}
+                  label={`${i + 1} | ${s.date} | ${s.time}`}
                 />
               ))}
             </FormGroup>

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -59,6 +59,7 @@ export default function PaymentDetail({
   const [remaining, setRemaining] = useState<number>(
     payment.remainingAmount ?? Number(payment.amount) ?? 0,
   )
+  const [ordinals, setOrdinals] = useState<Record<string, number>>({})
 
   useEffect(() => {
     let cancelled = false
@@ -163,11 +164,22 @@ export default function PaymentDetail({
               assigned,
               assignedToOther,
               inRetainer,
+              startDate,
             }
           }),
         )
 
         if (cancelled) return
+        const map: Record<string, number> = {}
+        ;[...rows]
+          .sort(
+            (a, b) =>
+              (a.startDate?.getTime() || 0) - (b.startDate?.getTime() || 0),
+          )
+          .forEach((r, i) => {
+            map[r.id] = i + 1
+          })
+        setOrdinals(map)
         setAssignedSessions(rows.filter((r) => r.assigned && !r.inRetainer))
         setAvailable(
           rows.filter(
@@ -277,7 +289,7 @@ export default function PaymentDetail({
             variant="h6"
             sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
           >
-            {`${i + 1} | ${s.date} | ${s.time}`}
+            {`${ordinals[s.id] ?? i + 1} | ${s.date} | ${s.time}`}
           </Typography>
         ))}
         {remaining > 0 && (
@@ -293,7 +305,7 @@ export default function PaymentDetail({
                       disabled={assigning || (s.rate || 0) > remaining}
                     />
                   }
-                  label={`${i + 1} | ${s.date} | ${s.time}`}
+                  label={`${ordinals[s.id] ?? i + 1} | ${s.date} | ${s.time}`}
                 />
               ))}
             </FormGroup>

--- a/components/StudentDialog/PaymentHistory.tsx
+++ b/components/StudentDialog/PaymentHistory.tsx
@@ -8,6 +8,7 @@ import {
   TableBody,
   CircularProgress,
   Typography,
+  TableSortLabel,
 } from '@mui/material'
 import { collection, doc, getDoc, getDocs, orderBy, query } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
@@ -60,6 +61,8 @@ export default function PaymentHistory({
   const [payments, setPayments] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [detail, setDetail] = useState<any | null>(null)
+  const [sortField, setSortField] = useState<'amount' | 'paymentMade'>('paymentMade')
+  const [sortAsc, setSortAsc] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -103,6 +106,18 @@ export default function PaymentHistory({
     }
   }, [abbr])
 
+  const sortedPayments = [...payments].sort((a, b) => {
+    const av =
+      sortField === 'amount'
+        ? Number(a.amount) || 0
+        : a.paymentMade?.toDate?.()?.getTime?.() || 0
+    const bv =
+      sortField === 'amount'
+        ? Number(b.amount) || 0
+        : b.paymentMade?.toDate?.()?.getTime?.() || 0
+    return sortAsc ? av - bv : bv - av
+  })
+
   if (detail)
     return (
       <PaymentDetail
@@ -132,15 +147,39 @@ export default function PaymentHistory({
                   Session Date/Time
                 </TableCell>
                 <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
-                  Amount Received
+                  <TableSortLabel
+                    active={sortField === 'amount'}
+                    direction={sortField === 'amount' && sortAsc ? 'asc' : 'desc'}
+                    onClick={() => {
+                      if (sortField === 'amount') setSortAsc((s) => !s)
+                      else {
+                        setSortField('amount')
+                        setSortAsc(true)
+                      }
+                    }}
+                  >
+                    Amount Received
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
-                  Payment Made On
+                  <TableSortLabel
+                    active={sortField === 'paymentMade'}
+                    direction={sortField === 'paymentMade' && sortAsc ? 'asc' : 'desc'}
+                    onClick={() => {
+                      if (sortField === 'paymentMade') setSortAsc((s) => !s)
+                      else {
+                        setSortField('paymentMade')
+                        setSortAsc(false)
+                      }
+                    }}
+                  >
+                    Payment Made On
+                  </TableSortLabel>
                 </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {payments.map((p) => (
+              {sortedPayments.map((p) => (
                 <TableRow key={p.id} hover onClick={() => setDetail(p)}>
                   <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
                     {formatDateTime(p.sessionDate)}

--- a/components/StudentDialog/PaymentHistory.tsx
+++ b/components/StudentDialog/PaymentHistory.tsx
@@ -113,14 +113,13 @@ export default function PaymentHistory({
   }, [account, abbr, onTitleChange])
 
   const sortedPayments = [...payments].sort((a, b) => {
-    const av =
-      sortField === 'amount'
-        ? Number(a.amount) || 0
-        : a.paymentMade?.toDate?.()?.getTime?.() || 0
-    const bv =
-      sortField === 'amount'
-        ? Number(b.amount) || 0
-        : b.paymentMade?.toDate?.()?.getTime?.() || 0
+    const ts = (v: any) => {
+      if (!v) return 0
+      const d = typeof v.toDate === 'function' ? v.toDate() : new Date(v)
+      return isNaN(d.getTime()) ? 0 : d.getTime()
+    }
+    const av = sortField === 'amount' ? Number(a.amount) || 0 : ts(a.paymentMade)
+    const bv = sortField === 'amount' ? Number(b.amount) || 0 : ts(b.paymentMade)
     return sortAsc ? av - bv : bv - av
   })
 

--- a/components/StudentDialog/PaymentHistory.tsx
+++ b/components/StudentDialog/PaymentHistory.tsx
@@ -54,9 +54,11 @@ const formatDate = (v: any) => {
 export default function PaymentHistory({
   abbr,
   account,
+  onTitleChange,
 }: {
   abbr: string
   account: string
+  onTitleChange?: (title: string) => void
 }) {
   const [payments, setPayments] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
@@ -106,6 +108,10 @@ export default function PaymentHistory({
     }
   }, [abbr])
 
+  useEffect(() => {
+    onTitleChange?.(`${account} - Billing - Payment History`)
+  }, [account, abbr, onTitleChange])
+
   const sortedPayments = [...payments].sort((a, b) => {
     const av =
       sortField === 'amount'
@@ -125,6 +131,7 @@ export default function PaymentHistory({
         account={account}
         payment={detail}
         onBack={() => setDetail(null)}
+        onTitleChange={onTitleChange}
       />
     )
 
@@ -144,7 +151,7 @@ export default function PaymentHistory({
             <TableHead>
               <TableRow>
                 <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
-                  Session Date/Time
+                  For session
                 </TableCell>
                 <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
                   <TableSortLabel

--- a/components/StudentDialog/PaymentHistory.tsx
+++ b/components/StudentDialog/PaymentHistory.tsx
@@ -7,13 +7,32 @@ import {
   TableCell,
   TableBody,
   CircularProgress,
+  Typography,
 } from '@mui/material'
-import { collection, getDocs, orderBy, query } from 'firebase/firestore'
+import { collection, doc, getDoc, getDocs, orderBy, query } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 import PaymentDetail from './PaymentDetail'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(n)
+
+const formatDateTime = (v: any) => {
+  if (!v) return 'N/A'
+  try {
+    const d = v.toDate ? v.toDate() : new Date(v)
+    return isNaN(d.getTime())
+      ? 'N/A'
+      : d.toLocaleString('en-US', {
+          month: 'short',
+          day: '2-digit',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        })
+  } catch {
+    return 'N/A'
+  }
+}
 
 const formatDate = (v: any) => {
   if (!v) return 'N/A'
@@ -49,11 +68,28 @@ export default function PaymentHistory({
         const snap = await getDocs(
           query(
             collection(db, 'Students', abbr, 'Payments'),
-            orderBy('paymentMade', 'desc')
-          )
+            orderBy('paymentMade', 'desc'),
+          ),
         )
         if (cancelled) return
-        setPayments(snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })))
+        const list = await Promise.all(
+          snap.docs.map(async (d) => {
+            const data = d.data() as any
+            let sessionDate: any = null
+            const first = data.assignedSessions?.[0]
+            if (first) {
+              try {
+                const sess = await getDoc(doc(db, 'Sessions', first))
+                const sdata = sess.data() as any
+                sessionDate = sdata?.origStartTimestamp
+              } catch (e) {
+                console.error('fetch session for payment failed', e)
+              }
+            }
+            return { id: d.id, ...data, sessionDate }
+          }),
+        )
+        setPayments(list)
       } catch (e) {
         console.error('load payments failed', e)
         if (cancelled) return
@@ -82,26 +118,44 @@ export default function PaymentHistory({
       {loading ? (
         <CircularProgress />
       ) : (
-        <Table size="small" sx={{ cursor: 'pointer' }}>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>Amount</TableCell>
-              <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>Date</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {payments.map((p) => (
-              <TableRow key={p.id} hover onClick={() => setDetail(p)}>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {formatCurrency(Number(p.amount) || 0)}
+        <>
+          <Typography
+            variant="subtitle1"
+            sx={{ fontFamily: 'Cantata One', textDecoration: 'underline', mb: 1 }}
+          >
+            Payment History
+          </Typography>
+          <Table size="small" sx={{ cursor: 'pointer' }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+                  Session Date/Time
                 </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {formatDate(p.paymentMade)}
+                <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+                  Amount Received
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+                  Payment Made On
                 </TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {payments.map((p) => (
+                <TableRow key={p.id} hover onClick={() => setDetail(p)}>
+                  <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                    {formatDateTime(p.sessionDate)}
+                  </TableCell>
+                  <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                    {formatCurrency(Number(p.amount) || 0)}
+                  </TableCell>
+                  <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                    {formatDate(p.paymentMade)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </>
       )}
     </Box>
   )

--- a/components/StudentDialog/RetainerModal.tsx
+++ b/components/StudentDialog/RetainerModal.tsx
@@ -119,16 +119,24 @@ export default function RetainerModal({
           sx={{ mb: 1 }}
           InputLabelProps={{ shrink: true, sx: { fontFamily: 'Newsreader', fontWeight: 200 } }}
           inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
+          helperText={`Balance Due: ${new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(balanceDue)}`}
+          FormHelperTextProps={{ sx: { fontFamily: 'Newsreader', fontWeight: 500 } }}
         />
-        <Typography sx={{ fontFamily: 'Newsreader', fontWeight: 500, mb: 2 }}>
-          Balance Due: {new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(balanceDue)}
-        </Typography>
         {error && (
           <Typography color="error" sx={{ mb: 2 }}>
             {error}
           </Typography>
         )}
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+        <Box
+          sx={{
+            borderTop: 1,
+            borderColor: 'divider',
+            mt: 2,
+            pt: 1,
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
           <Button onClick={() => onClose(false)} disabled={saving}>
             Close
           </Button>

--- a/components/StudentDialog/RetainerModal.tsx
+++ b/components/StudentDialog/RetainerModal.tsx
@@ -92,6 +92,7 @@ export default function RetainerModal({
         >
           {retainer ? 'Edit Retainer' : 'Add Retainer'}
         </Typography>
+        {/* TODO: replace TextField type="date" with MUI DatePicker + shouldDisableDate to gray out overlapping ranges. */}
         <TextField
           type="date"
           label="Start Date"

--- a/components/StudentDialog/RetainerModal.tsx
+++ b/components/StudentDialog/RetainerModal.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react'
+import { Box, Button, TextField, Typography } from '@mui/material'
+import { addRetainer, calculateEndDate, RetainerDoc } from '../../lib/retainer'
+
+const formatDate = (d: Date | null) =>
+  d
+    ? d.toLocaleDateString('en-US', {
+        month: 'short',
+        day: '2-digit',
+        year: 'numeric',
+      })
+    : '-'
+
+export default function RetainerModal({
+  abbr,
+  balanceDue,
+  retainer,
+  nextStart,
+  onClose,
+}: {
+  abbr: string
+  balanceDue: number
+  retainer?: RetainerDoc & { id: string }
+  nextStart?: Date
+  onClose: (saved: boolean) => void
+}) {
+  const [start, setStart] = useState<string>(() => {
+    if (retainer) return retainer.retainerStarts.toDate().toISOString().slice(0, 10)
+    if (nextStart) {
+      const d = new Date(nextStart)
+      d.setDate(d.getDate() + 1)
+      return d.toISOString().slice(0, 10)
+    }
+    return ''
+  })
+  const [rate, setRate] = useState<string>(() =>
+    retainer ? String(retainer.retainerRate) : '',
+  )
+  const [error, setError] = useState<string>('')
+  const [saving, setSaving] = useState(false)
+
+  const startDate = start ? new Date(start) : null
+  const endDate = startDate ? calculateEndDate(startDate) : null
+
+  const handleSave = async () => {
+    if (!startDate || !rate) return
+    const numRate = Number(rate)
+    if (numRate > balanceDue) {
+      setError(
+        'Insufficient balance to add retainer. Please record a payment first.',
+      )
+      return
+    }
+    setError('')
+    setSaving(true)
+    try {
+      await addRetainer(abbr, startDate, numRate)
+      onClose(true)
+    } catch (e: any) {
+      setError(String(e.message || e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        bgcolor: 'rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          bgcolor: 'background.paper',
+          p: 4,
+          width: 360,
+          maxWidth: '90%',
+          textAlign: 'left',
+        }}
+      >
+        <Typography
+          variant="h6"
+          sx={{ fontFamily: 'Cantata One', mb: 2 }}
+        >
+          {retainer ? 'Edit Retainer' : 'Add Retainer'}
+        </Typography>
+        <TextField
+          type="date"
+          label="Start Date"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          fullWidth
+          sx={{ mb: 2 }}
+          InputLabelProps={{ shrink: true, sx: { fontFamily: 'Newsreader', fontWeight: 200 } }}
+          inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
+        />
+        <TextField
+          label="End Date"
+          value={formatDate(endDate)}
+          fullWidth
+          sx={{ mb: 2 }}
+          InputProps={{ readOnly: true, sx: { fontFamily: 'Newsreader', fontWeight: 500 } }}
+          InputLabelProps={{ shrink: true, sx: { fontFamily: 'Newsreader', fontWeight: 200 } }}
+        />
+        <TextField
+          label="Rate"
+          value={rate}
+          onChange={(e) => setRate(e.target.value)}
+          type="number"
+          fullWidth
+          sx={{ mb: 1 }}
+          InputLabelProps={{ shrink: true, sx: { fontFamily: 'Newsreader', fontWeight: 200 } }}
+          inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
+        />
+        <Typography sx={{ fontFamily: 'Newsreader', fontWeight: 500, mb: 2 }}>
+          Balance Due: {new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD' }).format(balanceDue)}
+        </Typography>
+        {error && (
+          <Typography color="error" sx={{ mb: 2 }}>
+            {error}
+          </Typography>
+        )}
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+          <Button onClick={() => onClose(false)} disabled={saving}>
+            Close
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={saving || !start || !rate}
+          >
+            Save
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+

--- a/components/StudentDialog/RetainersTab.tsx
+++ b/components/StudentDialog/RetainersTab.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  TableSortLabel,
+} from '@mui/material'
+import { collection, getDocs } from 'firebase/firestore'
+import { db } from '../../lib/firebase'
+import { RetainerDoc } from '../../lib/retainer'
+import RetainerModal from './RetainerModal'
+
+const formatDate = (v: any) => {
+  try {
+    const d = v?.toDate ? v.toDate() : new Date(v)
+    return isNaN(d.getTime())
+      ? '-'
+      : d.toLocaleDateString('en-US', {
+          month: 'short',
+          day: '2-digit',
+          year: 'numeric',
+        })
+  } catch {
+    return '-'
+  }
+}
+
+interface RetRow extends RetainerDoc {
+  id: string
+}
+
+export default function RetainersTab({
+  abbr,
+  balanceDue,
+}: {
+  abbr: string
+  balanceDue: number
+}) {
+  const [rows, setRows] = useState<RetRow[]>([])
+  const [sortAsc, setSortAsc] = useState(true)
+  const [modal, setModal] = useState<{
+    open: boolean
+    retainer?: RetRow
+    nextStart?: Date
+  }>({ open: false })
+
+  const load = async () => {
+    try {
+      const snap = await getDocs(collection(db, 'Students', abbr, 'Retainers'))
+      const list = snap.docs
+        .map((d) => ({ id: d.id, ...(d.data() as RetainerDoc) }))
+        .sort((a, b) =>
+          a.retainerStarts.toDate().getTime() - b.retainerStarts.toDate().getTime(),
+        )
+      setRows(list)
+    } catch (e) {
+      console.error('load retainers failed', e)
+      setRows([])
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [abbr])
+
+  const sortedRows = [...rows].sort((a, b) => {
+    const diff =
+      a.retainerStarts.toDate().getTime() - b.retainerStarts.toDate().getTime()
+    return sortAsc ? diff : -diff
+  })
+
+  const today = new Date()
+
+  const getStatus = (r: RetRow, idx: number) => {
+    const start = r.retainerStarts.toDate()
+    const end = r.retainerEnds.toDate()
+    const next = rows[idx + 1]
+    if (today >= start && today <= end) {
+      const daysLeft = Math.ceil((end.getTime() - today.getTime()) / 86400000)
+      if (daysLeft <= 7) {
+        if (daysLeft === 7) return { text: 'Expiring in a week', color: 'error.main' }
+        if (daysLeft === 1)
+          return { text: 'Expiring tomorrow', color: 'error.main' }
+        if (daysLeft === 0)
+          return { text: 'Expiring today', color: 'error.main' }
+        return { text: `Expiring in ${daysLeft} days`, color: 'error.main' }
+      }
+      return { text: 'Active', color: 'success.main' }
+    }
+    if (today < start) {
+      const days = Math.ceil((start.getTime() - today.getTime()) / 86400000)
+      if (days <= 7)
+        return { text: `Upcoming in ${days} days`, color: 'info.light' }
+      return {
+        text: `Upcoming retainer starts on ${formatDate(start)}`,
+        color: 'info.light',
+      }
+    }
+    // expired
+    if (next) {
+      const nextStart = next.retainerStarts.toDate()
+      const days = Math.ceil((nextStart.getTime() - today.getTime()) / 86400000)
+      if (days <= 7)
+        return {
+          text: `Upcoming retainer starts in ${days} days`,
+          color: 'success.light',
+        }
+      return {
+        text: `Upcoming retainer starts on ${formatDate(nextStart)}`,
+        color: 'success.light',
+      }
+    }
+    return { text: 'Expired', color: 'error.main' }
+  }
+
+  return (
+    <Box sx={{ p: 1, textAlign: 'left', height: '100%' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+        <Typography
+          variant="subtitle1"
+          sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
+        >
+          Retainers
+        </Typography>
+        <Button
+          variant="contained"
+          onClick={() =>
+            setModal({
+              open: true,
+              nextStart: rows[rows.length - 1]
+                ? rows[rows.length - 1].retainerEnds.toDate()
+                : undefined,
+            })
+          }
+        >
+          Add Next Retainer
+        </Button>
+      </Box>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+              <TableSortLabel
+                active
+                direction={sortAsc ? 'asc' : 'desc'}
+                onClick={() => setSortAsc((s) => !s)}
+              >
+                Retainer
+              </TableSortLabel>
+            </TableCell>
+            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+              Coverage Period
+            </TableCell>
+            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+              Rate
+            </TableCell>
+            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+              Status
+            </TableCell>
+            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+              Actions
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedRows.map((r, idx) => {
+            const status = getStatus(r, idx)
+            const active = today >= r.retainerStarts.toDate() && today <= r.retainerEnds.toDate()
+            return (
+              <TableRow key={r.id} hover selected={active}>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  {r.id}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  {`${formatDate(r.retainerStarts)} – ${formatDate(r.retainerEnds)}`}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  {new Intl.NumberFormat(undefined, {
+                    style: 'currency',
+                    currency: 'HKD',
+                  }).format(r.retainerRate)}
+                </TableCell>
+                <TableCell
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 500, color: status.color }}
+                  title={status.text}
+                >
+                  {status.text}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  <Button
+                    size="small"
+                    onClick={() => setModal({ open: true, retainer: r })}
+                  >
+                    Edit
+                  </Button>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+      {modal.open && (
+        <RetainerModal
+          abbr={abbr}
+          balanceDue={balanceDue}
+          retainer={modal.retainer}
+          nextStart={modal.nextStart}
+          onClose={(saved) => {
+            setModal({ open: false })
+            if (saved) load()
+          }}
+        />
+      )}
+    </Box>
+  )
+}
+

--- a/components/StudentDialog/icons.tsx
+++ b/components/StudentDialog/icons.tsx
@@ -1,0 +1,3 @@
+import EditNoteIcon from '@mui/icons-material/EditNote'
+
+export const WriteIcon = EditNoteIcon

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -11,11 +11,26 @@ export const isLastDayOfMonth = (d: Date): boolean => {
   return d.getDate() === test.getDate()
 }
 
-export const endOfNextMonthAligned = (d: Date): Date => {
-  const endNext = new Date(d.getFullYear(), d.getMonth() + 2, 0)
-  if (isLastDayOfMonth(d)) return endNext
-  const day = Math.min(d.getDate(), endNext.getDate())
-  return new Date(d.getFullYear(), d.getMonth() + 1, day)
+export const endOfNextMonthAligned = (start: Date): Date => {
+  const y = start.getFullYear()
+  const m = start.getMonth()
+  const d = start.getDate()
+
+  // candidate: same day next month
+  const sameDayNext = new Date(y, m + 1, d)
+  // If month rolled (day doesn't exist), fallback to last day of next month
+  const lastOfNext = new Date(y, m + 2, 0)
+
+  let end: Date
+  if (sameDayNext.getMonth() === (m + 1) % 12) {
+    // use the day BEFORE the same-day-next-month
+    end = new Date(y, m + 1, d - 1)
+  } else {
+    // e.g., Jan 31 -> Feb doesn't have 31 -> end = last day of next month
+    end = lastOfNext
+  }
+  end.setHours(23, 59, 59, 0)
+  return end
 }
 
 export const daysUntil = (target: Date): number => {

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,28 @@
+export const formatMMMDDYYYY = (d: Date): string => {
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  })
+}
+
+export const isLastDayOfMonth = (d: Date): boolean => {
+  const test = new Date(d.getFullYear(), d.getMonth() + 1, 0)
+  return d.getDate() === test.getDate()
+}
+
+export const endOfNextMonthAligned = (d: Date): Date => {
+  const endNext = new Date(d.getFullYear(), d.getMonth() + 2, 0)
+  if (isLastDayOfMonth(d)) return endNext
+  const day = Math.min(d.getDate(), endNext.getDate())
+  return new Date(d.getFullYear(), d.getMonth() + 1, day)
+}
+
+export const daysUntil = (target: Date): number => {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const t = new Date(target)
+  t.setHours(0, 0, 0, 0)
+  const diff = t.getTime() - today.getTime()
+  return Math.round(diff / 86400000)
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,29 @@
+import { Timestamp } from 'firebase/firestore'
+import { RetainerDoc } from './retainer'
+
+export interface SessionInfo {
+  id: string
+  start: Date
+  paymentAssigned?: boolean
+}
+
+/**
+ * Return sessions eligible for manual payment assignment.
+ * Excludes sessions already assigned a payment and those falling within any retainer period.
+ */
+export const filterEligibleSessions = (
+  sessions: SessionInfo[],
+  retainers: RetainerDoc[],
+): SessionInfo[] => {
+  const covered = retainers.map((r) => ({
+    start: r.retainerStarts.toDate(),
+    end: r.retainerEnds.toDate(),
+  }))
+
+  return sessions.filter((s) => {
+    if (s.paymentAssigned) return false
+    return !covered.some(
+      (p) => s.start >= p.start && s.start <= p.end,
+    )
+  })
+}

--- a/lib/retainer.ts
+++ b/lib/retainer.ts
@@ -1,0 +1,97 @@
+// lib/retainer.ts
+
+import {
+  collection,
+  doc,
+  getDocs,
+  setDoc,
+  Timestamp,
+} from 'firebase/firestore'
+import { db } from './firebase'
+
+export interface RetainerDoc {
+  retainerStarts: Timestamp
+  retainerEnds: Timestamp
+  retainerRate: number
+  timestamp: Timestamp
+  editedBy?: string
+}
+
+/**
+ * Calculate the end date for a retainer given a start date. The end date is the
+ * same day in the following month. If the start date is the final day of the
+ * month the end date will also be the final day of the next month.
+ */
+export const calculateEndDate = (start: Date): Date => {
+  const year = start.getFullYear()
+  const month = start.getMonth()
+  const day = start.getDate()
+
+  const daysInCurrentMonth = new Date(year, month + 1, 0).getDate()
+  const daysInNextMonth = new Date(year, month + 2, 0).getDate()
+
+  const isLastDay = day === daysInCurrentMonth
+  const endDay = isLastDay ? daysInNextMonth : Math.min(day, daysInNextMonth)
+
+  return new Date(year, month + 1, endDay)
+}
+
+/**
+ * Add a retainer record for the given student. Throws an Error if the new
+ * retainer period overlaps an existing one.
+ */
+export const addRetainer = async (
+  abbr: string,
+  start: Date,
+  rate: number,
+  editedBy = 'system',
+): Promise<void> => {
+  const startDate = new Date(start)
+  startDate.setHours(0, 0, 0, 0)
+
+  const endDate = calculateEndDate(startDate)
+  endDate.setHours(23, 59, 59, 0)
+
+  const retainersCol = collection(db, 'Students', abbr, 'Retainers')
+  const existing = await getDocs(retainersCol)
+
+  existing.forEach((d) => {
+    const data = d.data() as RetainerDoc
+    const s = data.retainerStarts.toDate()
+    const e = data.retainerEnds.toDate()
+    if (startDate <= e && endDate >= s) {
+      throw new Error('Retainer period overlaps existing retainer')
+    }
+  })
+
+  const idx = String(existing.size + 1).padStart(3, '0')
+  const today = new Date()
+  const yyyyMMdd = today.toISOString().slice(0, 10).replace(/-/g, '')
+  const docName = `${abbr}-RT-${idx}-${yyyyMMdd}`
+
+  await setDoc(doc(retainersCol, docName), {
+    retainerStarts: Timestamp.fromDate(startDate),
+    retainerEnds: Timestamp.fromDate(endDate),
+    retainerRate: rate,
+    timestamp: Timestamp.fromDate(today),
+    editedBy,
+  })
+}
+
+/**
+ * Fetch the most recent retainer for a student based on start date.
+ */
+export const getLatestRetainer = async (
+  abbr: string,
+): Promise<RetainerDoc | undefined> => {
+  const snap = await getDocs(collection(db, 'Students', abbr, 'Retainers'))
+  if (snap.empty) return undefined
+  return snap.docs
+    .map((d) => d.data() as RetainerDoc)
+    .sort(
+      (a, b) =>
+        b.retainerStarts.toDate().getTime() -
+        a.retainerStarts.toDate().getTime(),
+    )[0]
+}
+

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -1,0 +1,36 @@
+import { collection, getDocs } from 'firebase/firestore'
+import { db } from './firebase'
+
+export const computeSessionStart = async (
+  sessionId: string,
+  snapshotData?: any,
+): Promise<Date | null> => {
+  // Load a minimal history to resolve reschedules
+  const [histSnap] = await Promise.all([
+    getDocs(collection(db, 'Sessions', sessionId, 'appointmentHistory')),
+  ])
+  const hist = histSnap.docs
+    .map((d) => d.data() as any)
+    .sort((a, b) => {
+      const ta = a.timestamp?.toDate?.() ?? new Date(0)
+      const tb = b.timestamp?.toDate?.() ?? new Date(0)
+      return tb.getTime() - ta.getTime()
+    })[0]
+
+  let start: any = snapshotData?.origStartTimestamp
+  if (hist?.newStartTimestamp != null) start = hist.newStartTimestamp
+
+  const d = start?.toDate ? start.toDate() : new Date(start)
+  return d && !isNaN(d.getTime()) ? d : null
+}
+
+export const fmtDate = (d: Date) =>
+  d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  })
+
+export const fmtTime = (d: Date) =>
+  d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { SnackbarProvider } from 'notistack';
 import type { AppProps } from 'next/app';
 import { setupClientLogging } from '../lib/clientLogger';
 import { Newsreader, Cantata_One, Nunito } from 'next/font/google';
+import '../styles/studentDialog.css';
 
 if (typeof window !== 'undefined') {
   setupClientLogging();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import { SessionProvider, useSession } from 'next-auth/react';
 import { SnackbarProvider } from 'notistack';
 import type { AppProps } from 'next/app';
 import { setupClientLogging } from '../lib/clientLogger';
-import { Newsreader, Cantata_One } from 'next/font/google';
+import { Newsreader, Cantata_One, Nunito } from 'next/font/google';
 
 if (typeof window !== 'undefined') {
   setupClientLogging();
@@ -13,10 +13,11 @@ const newsreader = Newsreader({ subsets: ['latin'], weight: ['200', '500'] });
 // Cantata One exposes only a regular 400 weight, so we must specify it
 // explicitly to satisfy the Next.js font loader typings.
 const cantata = Cantata_One({ subsets: ['latin'], weight: '400' });
+const nunito = Nunito({ subsets: ['latin'], weight: ['400', '700'], variable: '--font-nunito' });
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${newsreader.className} ${cantata.className}`}>
+    <div className={`${newsreader.className} ${cantata.className} ${nunito.variable}`}>
       <SessionProvider session={pageProps.session}>
         <SnackbarProvider maxSnack={3}>
           <Component {...pageProps} />

--- a/styles/studentDialog.css
+++ b/styles/studentDialog.css
@@ -1,0 +1,13 @@
+.student-dialog-modal .MuiDialog-paper {
+  padding: 24px;
+}
+
+.student-heading {
+  font-family: 'Cantata One', serif;
+  text-decoration: underline;
+}
+
+.student-row {
+  font-family: 'Newsreader', serif;
+  font-weight: 500;
+}

--- a/styles/studentDialog.css
+++ b/styles/studentDialog.css
@@ -13,6 +13,7 @@
 }
 
 .floating-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: var(--font-nunito), system-ui, -apple-system, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-weight: 700;
 }

--- a/styles/studentDialog.css
+++ b/styles/studentDialog.css
@@ -11,3 +11,8 @@
   font-family: 'Newsreader', serif;
   font-weight: 500;
 }
+
+.floating-title {
+  font-family: 'Nunito', sans-serif;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary
- store retainer periods as documents under Students/{abbr}/Retainers
- block overlapping retainer periods and normalize stored timestamps
- surface latest retainer details in Billing tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68946ea8d150832394867cfae15deef4