### PR TITLE
Listen to student doc balance and update billing hooks

### DIFF
--- a/common/InlineEdit.tsx
+++ b/common/InlineEdit.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import { TextField, MenuItem, Typography } from '@mui/material'
+import { Z_INDEX } from '../lib/zindex'
 import { collection, getDocs, doc, setDoc } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 
@@ -71,6 +72,7 @@ export default function InlineEdit({
         [fieldKey]: v,
         timestamp: today,
       })
+      await setDoc(doc(db, col, docId), { [fieldKey]: v }, { merge: true })
       setDraft(v)
       onSaved?.(v)
     } catch (e) {
@@ -149,6 +151,12 @@ export default function InlineEdit({
           setEditing(false)
         }}
         size="small"
+        SelectProps={{
+          MenuProps: {
+            container: document.body,
+            slotProps: { paper: { sx: { zIndex: Z_INDEX.menu } } },
+          },
+        }}
       >
         {options?.map(o => (
           <MenuItem key={o} value={o}>{o}</MenuItem>

--- a/components/StudentDialog/FloatingWindow.tsx
+++ b/components/StudentDialog/FloatingWindow.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createPortal } from 'react-dom'
 import { Rnd } from 'react-rnd'
 import { Box, IconButton, Typography } from '@mui/material'
+import { Z_INDEX } from '../../lib/zindex'
 import CloseIcon from '@mui/icons-material/Close'
 
 interface FloatingWindowProps {
@@ -28,7 +29,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
             right: 0,
             bottom: 0,
             bgcolor: 'background.paper',
-            zIndex: 1500,
+            zIndex: Z_INDEX.floatingWindow,
             display: 'flex',
             flexDirection: 'column',
           }}
@@ -70,7 +71,7 @@ export default function FloatingWindow({ title, children, onClose, actions }: Fl
         minWidth={300}
         minHeight={200}
         bounds="window"
-        style={{ zIndex: 1500 }}
+        style={{ zIndex: Z_INDEX.floatingWindow }}
         dragHandleClassName={HANDLE_CLASS}
       >
         <Box

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -188,10 +188,9 @@ export default function OverviewTab({
     return String(v)
   }
 
-  const loading =
-    Object.values(personalLoading).some((v) => v) ||
-    Object.values(billingLoading).some((v) => v) ||
-    overviewLoading
+  // We no longer block the entire dialog with an overlay.
+  // Each field shows its own inline spinner while loading.
+  const loading = false
 
   const selected =
     tab === 'billing' && subTab ? `billing-${subTab}` : tab
@@ -202,21 +201,7 @@ export default function OverviewTab({
       <FloatingWindow onClose={closeAndReset} title={title} actions={actions}>
         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%', maxHeight: '100%', maxWidth: '100%', overflow: 'hidden' }}>
           <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative', alignItems: 'flex-start', maxHeight: '100%', maxWidth: '100%' }}>
-            {loading && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  inset: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  bgcolor: 'background.paper',
-                  zIndex: 1,
-                }}
-              >
-                <CircularProgress />
-              </Box>
-            )}
+            {/* No blocking overlay. Show inline spinners per-field below. */}
 
             <Box
               sx={{
@@ -224,7 +209,6 @@ export default function OverviewTab({
                 pr: 3,
                 overflow: 'auto',
                 textAlign: 'left',
-                display: loading ? 'none' : 'block',
                 maxHeight: '100%',
                 maxWidth: '100%',
               }}
@@ -403,6 +387,7 @@ export default function OverviewTab({
               >
                 <RetainersTab
                   abbr={abbr}
+                  account={account}
                   balanceDue={Number(billing.balanceDue) || 0}
                 />
               </Box>
@@ -429,7 +414,7 @@ export default function OverviewTab({
                       : 'none',
                 }}
               >
-                <VouchersTab abbr={abbr} />
+                <VouchersTab abbr={abbr} account={account} />
               </Box>
             </Box>
 
@@ -442,7 +427,7 @@ export default function OverviewTab({
                 borderColor: 'divider',
                 minWidth: 140,
                 alignItems: 'flex-end',
-                display: loading ? 'none' : 'flex',
+                display: 'flex',
               }}
             >
               <Tab

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -10,21 +10,20 @@ import {
   TableCell,
   TableBody,
   TableSortLabel,
+  CircularProgress,
 } from '@mui/material'
-import {
-  collection,
-  doc,
-  getDocs,
-  query,
-  setDoc,
-  updateDoc,
-  where,
-} from 'firebase/firestore'
+import { doc, setDoc, updateDoc, onSnapshot, collection } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
-import { fmtDate, fmtTime } from '../../lib/sessions'
 import { formatMMMDDYYYY } from '../../lib/date'
 import { titleFor } from './title'
 import { PATHS, logPath } from '../../lib/paths'
+import { useBillingClient, useBilling } from '../../lib/billing/useBilling'
+import {
+  patchBillingAssignedSessions,
+  writeSummaryFromCache,
+  payRetainerPatch,
+  upsertUnpaidRetainerRow,
+} from '../../lib/liveRefresh'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, {
@@ -47,17 +46,71 @@ export default function PaymentDetail({
   onBack: () => void
   onTitleChange?: (title: string | null) => void
 }) {
-  const [available, setAvailable] = useState<any[]>([])
-  const [assignedSessions, setAssignedSessions] = useState<any[]>([])
   const [selected, setSelected] = useState<string[]>([])
   const [assigning, setAssigning] = useState(false)
   const [remaining, setRemaining] = useState<number>(
     payment.remainingAmount ?? Number(payment.amount) ?? 0,
   )
+  const [assignedSessionIds, setAssignedSessionIds] = useState<string[]>(
+    payment.assignedSessions || [],
+  )
+  const [assignedRetainerIds, setAssignedRetainerIds] = useState<string[]>(
+    payment.assignedRetainers || [],
+  )
   const [sortField, setSortField] = useState<'ordinal' | 'date' | 'time' | 'rate'>(
     'ordinal',
   )
   const [sortAsc, setSortAsc] = useState(true)
+  const qc = useBillingClient()
+  const { data: bill } = useBilling(abbr, account)
+  const [retainers, setRetainers] = useState<any[]>([])
+
+  const assignedSet = new Set(assignedSessionIds)
+  const sessionRows = bill
+    ? bill.rows
+        .filter(
+          (r) =>
+            !r.flags.cancelled &&
+            !r.flags.voucherUsed &&
+            !r.flags.inRetainer,
+        )
+        .map((r) => ({
+          id: r.id,
+          startMs: r.startMs,
+          date: r.date,
+          time: r.time,
+          rate: r.amountDue,
+          rateDisplay: r.displayRate,
+          assignedPaymentId: r.assignedPaymentId,
+        }))
+        .sort((a, b) => a.startMs - b.startMs)
+    : []
+  sessionRows.forEach((r: any, i: number) => {
+    r.ordinal = i + 1
+  })
+  const assignedSessions = sessionRows.filter((r) => assignedSet.has(r.id))
+  const availableSessions = sessionRows.filter(
+    (r) => !assignedSet.has(r.id) && !r.assignedPaymentId,
+  )
+  const retRows = retainers.map((r: any, i: number) => ({
+    id: `retainer:${r.retainerId}`,
+    retainerId: r.retainerId,
+    startMs: r.startMs,
+    date: (() => {
+      const d = new Date(r.startMs)
+      if (d.getDate() >= 21) d.setMonth(d.getMonth() + 1)
+      return d.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+    })(),
+    time: '',
+    rate: r.rate,
+    rateDisplay: formatCurrency(r.rate),
+    paymentId: r.paymentId,
+    ordinal: sessionRows.length + i + 1,
+  }))
+  const assignedRetainers = retRows.filter((r: any) => r.paymentId === payment.id)
+  const availableRetainers = retRows.filter((r: any) => !r.paymentId)
+  const assigned = [...assignedSessions, ...assignedRetainers]
+  const available = [...availableSessions, ...availableRetainers]
 
   const sortRows = (rows: any[]) => {
     const val = (r: any) => {
@@ -88,198 +141,60 @@ export default function PaymentDetail({
   }, [account, payment.paymentMade, onTitleChange])
 
   useEffect(() => {
-    let cancelled = false
-    ;(async () => {
-      try {
-        const baseRateHistPath = PATHS.baseRateHistory(abbr)
-        const baseRatePath = PATHS.baseRate(abbr)
-        const sessionsPath = PATHS.sessions
-        const retainersPath = PATHS.retainers(abbr)
-        logPath('baseRateHistory', baseRateHistPath)
-        logPath('baseRate', baseRatePath)
-        logPath('sessions', sessionsPath)
-        logPath('retainers', retainersPath)
-        const [histSnap, baseSnap, sessSnap, retSnap] = await Promise.all([
-          getDocs(collection(db, baseRateHistPath)),
-          getDocs(collection(db, baseRatePath)),
-          getDocs(query(collection(db, sessionsPath), where('sessionName', '==', account))),
-          getDocs(collection(db, retainersPath)),
-        ])
-
-        const baseRateDocs = [...histSnap.docs, ...baseSnap.docs]
-        const baseRates = baseRateDocs
-          .map((d) => {
-            const data = d.data() as any
-            return {
-              rate: data.rate ?? data.baseRate,
-              ts: data.timestamp?.toDate?.() ?? new Date(0),
-            }
-          })
-          .sort((a, b) => a.ts.getTime() - b.ts.getTime())
-
-        const retainerDocs = retSnap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }))
-        const retainers = retainerDocs.map((r) => {
-          const s = r.retainerStarts?.toDate?.() ?? new Date(0)
-          const e = r.retainerEnds?.toDate?.() ?? new Date(0)
-          return { start: s, end: e, id: r.id, rate: Number(r.retainerRate) || 0, paymentId: r.paymentId }
-        })
-
-        const rows = await Promise.all(
-          sessSnap.docs.map(async (sd) => {
-            const data = sd.data() as any
-            const ratePath = PATHS.sessionRate(sd.id)
-            const payPath = PATHS.sessionPayment(sd.id)
-            logPath('sessionRate', ratePath)
-            logPath('sessionPayment', payPath)
-            const voucherPath = PATHS.sessionVoucher(sd.id)
-            logPath('sessionVoucher', voucherPath)
-            const histPath = PATHS.sessionHistory(sd.id)
-            logPath('sessionHistory', histPath)
-            const [rateSnap, paySnap, voucherSnap, histSnap] = await Promise.all([
-              getDocs(collection(db, ratePath)),
-              getDocs(collection(db, payPath)),
-              getDocs(collection(db, voucherPath)),
-              getDocs(collection(db, histPath)),
-            ])
-
-            const parseDate = (v: any) => {
-              const d = v?.toDate ? v.toDate() : new Date(v)
-              return isNaN(d.getTime()) ? null : d
-            }
-            const hist = histSnap.docs
-              .map((d) => d.data() as any)
-              .sort((a, b) => {
-                const ta =
-                  a.changeTimestamp?.toDate?.() ??
-                  a.timestamp?.toDate?.() ??
-                  new Date(0)
-                const tb =
-                  b.changeTimestamp?.toDate?.() ??
-                  b.timestamp?.toDate?.() ??
-                  new Date(0)
-                return tb.getTime() - ta.getTime()
-              })[0]
-            let start =
-              hist?.newStartTimestamp ??
-              hist?.origStartTimestamp ??
-              data?.origStartTimestamp ??
-              data?.sessionDate ??
-              data?.startTimestamp
-            let end =
-              hist?.newEndTimestamp ??
-              hist?.origEndTimestamp ??
-              data?.origEndTimestamp ??
-              data?.endTimestamp
-            const startDate = parseDate(start)
-            const endDate = parseDate(end)
-            const date = startDate ? fmtDate(startDate) : '-'
-            const startStr = startDate ? fmtTime(startDate) : '-'
-            const endStr = endDate ? fmtTime(endDate) : ''
-            const time = startStr + (endStr ? `-${endStr}` : '')
-            const startMs = startDate?.getTime() ?? 0
-
-            const base = (() => {
-              if (!startDate || !baseRates.length) return 0
-              const entry = baseRates
-                .filter((b) => b.ts.getTime() <= startDate.getTime())
-                .pop()
-              return entry ? Number(entry.rate) || 0 : 0
-            })()
-
-            const rateHist = rateSnap.docs
-              .map((d) => d.data() as any)
-              .sort((a, b) => {
-                const ta = a.timestamp?.toDate?.() ?? new Date(0)
-                const tb = b.timestamp?.toDate?.() ?? new Date(0)
-                return tb.getTime() - ta.getTime()
-              })
-            const latestRate = rateHist[0]?.rateCharged
-            const rate = latestRate != null ? Number(latestRate) : base
-
-            const paymentIds = paySnap.docs.map(
-              (p) => (p.data() as any).paymentId as string,
-            )
-            const assigned = paymentIds.includes(payment.id)
-            const assignedToOther = paymentIds.length > 0 && !assigned
-
-            const inRetainer = retainers.some(
-              (r) => startDate && startDate >= r.start && startDate <= r.end,
-            )
-            const hasVoucher = (() => {
-              const entries = voucherSnap.docs
-                .map((v) => {
-                  const data = v.data() as any
-                  const ts =
-                    (data.timestamp?.toDate?.()?.getTime() ??
-                      new Date(data.timestamp).getTime()) ||
-                    0
-                  return { ...data, ts }
-                })
-                .sort((a, b) => a.ts - b.ts)
-              const latest = entries[entries.length - 1]
-              return !!latest && latest['free?'] === true
-            })()
-            const isCancelled =
-              (data.sessionType || '').toLowerCase() === 'cancelled'
-
-            return {
-              id: sd.id,
-              type: 'session',
-              date,
-              time,
-              rate,
-              assigned,
-              assignedToOther,
-              inRetainer,
-              startMs,
-              hasVoucher,
-              cancelled: isCancelled,
-            }
-          }),
-        )
-        const retainerRows = retainers.map((r) => {
-          const startDate = r.start
-          const date = fmtDate(startDate)
-          return {
-            id: `retainer:${r.id}`,
-            type: 'retainer',
-            date,
-            time: 'Retainer',
-            rate: r.rate,
-            assigned: r.paymentId === payment.id,
-            assignedToOther: r.paymentId && r.paymentId !== payment.id,
-            startMs: startDate.getTime(),
-            inRetainer: false,
-            hasVoucher: false,
-            cancelled: false,
-            retainerId: r.id,
-          }
-        })
-
-        if (cancelled) return
-        const filteredSessions = rows.filter(
-          (r) => !r.inRetainer && !r.hasVoucher && !r.cancelled,
-        )
-        const allRows: any[] = [...filteredSessions, ...retainerRows].sort(
-          (a, b) => a.startMs - b.startMs,
-        )
-        allRows.forEach((r, i) => {
-          r.ordinal = i + 1
-        })
-        setAssignedSessions(allRows.filter((r) => r.assigned))
-        setAvailable(allRows.filter((r) => !r.assigned && !r.assignedToOther))
-      } catch (e) {
-        console.error('load sessions failed', e)
-        if (!cancelled) {
-          setAssignedSessions([])
-          setAvailable([])
+    const unsub = onSnapshot(
+      doc(db, PATHS.payments(abbr), payment.id),
+      (snap) => {
+        const data = snap.data()
+        if (data) {
+          setRemaining(data.remainingAmount ?? Number(data.amount) ?? 0)
+          setAssignedSessionIds(data.assignedSessions || [])
+          setAssignedRetainerIds(data.assignedRetainers || [])
         }
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [abbr, account, payment.id])
+      },
+    )
+    return () => unsub()
+  }, [abbr, payment.id])
+
+  useEffect(() => {
+    const unsub = onSnapshot(
+      collection(db, PATHS.retainers(abbr)),
+      (snap) => {
+        const list: any[] = []
+        snap.forEach((d) => {
+          const r = d.data() as any
+          const start = r.retainerStarts?.toDate
+            ? r.retainerStarts.toDate()
+            : new Date(r.retainerStarts)
+          const end = r.retainerEnds?.toDate
+            ? r.retainerEnds.toDate()
+            : new Date(r.retainerEnds)
+          const rate = Number(r.retainerRate) || 0
+          const paymentId = r.paymentId || null
+          const startMs = start.getTime()
+          list.push({
+            id: `retainer:${d.id}`,
+            retainerId: d.id,
+            startMs,
+            rate,
+            paymentId,
+          })
+          upsertUnpaidRetainerRow(
+            qc,
+            abbr,
+            account,
+            d.id,
+            startMs,
+            end.getTime(),
+            rate,
+            !paymentId,
+          )
+        })
+        setRetainers(list)
+      },
+    )
+    return () => unsub()
+  }, [abbr, account, qc])
+
 
   const toggle = (id: string) => {
     setSelected((prev) =>
@@ -291,60 +206,57 @@ export default function PaymentDetail({
     const rate = available.find((s) => s.id === id)?.rate || 0
     return sum + rate
   }, 0)
+  const remainingAfterSelection = Math.max(0, remaining - totalSelected)
 
   const handleAssign = async () => {
     if (totalSelected > remaining) return
     setAssigning(true)
     try {
-      const newlyAssigned: any[] = []
-      const newAssignedRet: string[] = []
-      for (const id of selected) {
-        if (id.startsWith('retainer:')) {
-          const retId = id.replace('retainer:', '')
-          const ret = available.find((s) => s.id === id)
-          const rate = ret?.rate || 0
-          await updateDoc(doc(db, PATHS.retainers(abbr), retId), {
-            paymentId: payment.id,
-          })
-          if (ret) newlyAssigned.push(ret)
-          newAssignedRet.push(retId)
-        } else {
-          const session = available.find((s) => s.id === id)
-          const rate = session?.rate || 0
-          const sessionPayPath = PATHS.sessionPayment(id)
-          logPath('assignPayment', `${sessionPayPath}/${payment.id}`)
-          await setDoc(doc(db, sessionPayPath, payment.id), {
-            amount: rate,
-            paymentId: payment.id,
-            paymentMade: payment.paymentMade,
-          })
-          if (session) newlyAssigned.push(session)
-        }
+      const sessionIds = selected.filter((id) => !id.startsWith('retainer:'))
+      const retainerIds = selected
+        .filter((id) => id.startsWith('retainer:'))
+        .map((id) => id.replace('retainer:', ''))
+
+      for (const id of sessionIds) {
+        const session = available.find((s) => s.id === id)
+        const rate = session?.rate || 0
+        const sessionPayPath = PATHS.sessionPayment(id)
+        logPath('assignPayment', `${sessionPayPath}/${payment.id}`)
+        await setDoc(doc(db, sessionPayPath, payment.id), {
+          amount: rate,
+          paymentId: payment.id,
+          paymentMade: payment.paymentMade,
+        })
       }
-      const newAssigned = [
-        ...(payment.assignedSessions || []),
-        ...selected.filter((id) => !id.startsWith('retainer:')),
-      ]
+
+      for (const rid of retainerIds) {
+        const retPath = PATHS.retainers(abbr)
+        logPath('retainerPay', `${retPath}/${rid}`)
+        await updateDoc(doc(db, retPath, rid), { paymentId: payment.id })
+      }
+
+      const newAssignedSessions = [...assignedSessionIds, ...sessionIds]
+      const newAssignedRetainers = [...assignedRetainerIds, ...retainerIds]
       const newRemaining = remaining - totalSelected
       const payDocPath = PATHS.payments(abbr)
       logPath('updatePayment', `${payDocPath}/${payment.id}`)
       await updateDoc(doc(db, payDocPath, payment.id), {
-        assignedSessions: newAssigned,
-        assignedRetainers: [
-          ...(payment.assignedRetainers || []),
-          ...newAssignedRet,
-        ],
+        assignedSessions: newAssignedSessions,
+        assignedRetainers: newAssignedRetainers,
         remainingAmount: newRemaining,
       })
-      payment.assignedSessions = newAssigned
-      payment.assignedRetainers = [
-        ...(payment.assignedRetainers || []),
-        ...newAssignedRet,
-      ]
+      setAssignedSessionIds(newAssignedSessions)
+      setAssignedRetainerIds(newAssignedRetainers)
       setRemaining(newRemaining)
-      setAssignedSessions((a) => [...a, ...newlyAssigned])
-      setAvailable((s) => s.filter((sess) => !selected.includes(sess.id)))
       setSelected([])
+
+      if (sessionIds.length) {
+        patchBillingAssignedSessions(qc, abbr, account, sessionIds)
+      }
+      retainerIds.forEach((rid) =>
+        payRetainerPatch(qc, abbr, account, rid),
+      )
+      await writeSummaryFromCache(qc, abbr, account)
     } catch (e) {
       console.error('assign payment failed', e)
     } finally {
@@ -390,13 +302,18 @@ export default function PaymentDetail({
           variant="subtitle2"
           sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
         >
-          Remaining Amount:
+          Remaining amount:
         </Typography>
         <Typography
           variant="h6"
           sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
         >
-          {formatCurrency(remaining)}
+          {formatCurrency(remaining)}{' '}
+          {totalSelected > 0 && (
+            <Box component="span" sx={{ color: 'error.main' }}>
+              ({`-${formatCurrency(totalSelected)} = ${formatCurrency(remainingAfterSelection)}`})
+            </Box>
+          )}
         </Typography>
 
         <Typography
@@ -471,53 +388,68 @@ export default function PaymentDetail({
             </TableRow>
           </TableHead>
           <TableBody>
-            {sortRows(assignedSessions).map((s) => (
-              <TableRow key={s.id}>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {s.ordinal}
-                </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {s.date || '-'}
-                </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {s.time || '-'}
-                </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {formatCurrency(Number(s.rate) || 0)}
-                </TableCell>
-              </TableRow>
-            ))}
-            {sortRows(available).map((s) => (
-              <TableRow key={s.id}>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  <Checkbox
-                    checked={selected.includes(s.id)}
-                    onChange={() => toggle(s.id)}
-                    disabled={assigning || (s.rate || 0) > remaining}
-                    sx={{ p: 0, mr: 1 }}
-                  />
-                  {s.ordinal}
-                </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {s.date || '-'}
-                </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {s.time || '-'}
-                </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                  {formatCurrency(Number(s.rate) || 0)}
-                </TableCell>
-              </TableRow>
-            ))}
-            {assignedSessions.length === 0 && available.length === 0 && (
+            {!bill ? (
               <TableRow>
-                <TableCell
-                  colSpan={4}
-                  sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
-                >
-                  No sessions available.
+                <TableCell colSpan={4} align="center">
+                  <CircularProgress size={16} />
                 </TableCell>
               </TableRow>
+            ) : (
+              <>
+                {sortRows(assigned).map((s) => (
+                  <TableRow key={s.id}>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {s.ordinal ?? '-'}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {s.date || '-'}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {s.time || '-'}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {formatCurrency(Number(s.rate) || 0)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {sortRows(available).map((s) => (
+                  <TableRow key={s.id}>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      <Checkbox
+                        checked={selected.includes(s.id)}
+                        onChange={() => toggle(s.id)}
+                        disabled={
+                          assigning ||
+                          (!selected.includes(s.id) &&
+                            (s.rate || 0) >
+                              Math.max(0, remaining - totalSelected))
+                        }
+                        sx={{ p: 0, mr: 1 }}
+                      />
+                      {s.ordinal ?? '-'}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {s.date || '-'}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {s.time || '-'}
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                      {formatCurrency(Number(s.rate) || 0)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {assigned.length === 0 && available.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                    >
+                      No sessions available.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </>
             )}
           </TableBody>
         </Table>
@@ -526,7 +458,9 @@ export default function PaymentDetail({
             variant="contained"
             sx={{ mt: 1 }}
             onClick={handleAssign}
-            disabled={assigning || totalSelected === 0 || totalSelected > remaining}
+            disabled={
+              assigning || totalSelected === 0 || totalSelected > remaining
+            }
           >
             Assign
           </Button>

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -24,6 +24,7 @@ import {
   payRetainerPatch,
   upsertUnpaidRetainerRow,
 } from '../../lib/liveRefresh'
+import { computeStudentSummary, writeStudentSummary } from '../../lib/studentSummary'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, {
@@ -257,6 +258,8 @@ export default function PaymentDetail({
         payRetainerPatch(qc, abbr, account, rid),
       )
       await writeSummaryFromCache(qc, abbr, account)
+      const summary = await computeStudentSummary(abbr, account)
+      await writeStudentSummary(abbr, summary)
     } catch (e) {
       console.error('assign payment failed', e)
     } finally {

--- a/components/StudentDialog/PaymentModal.tsx
+++ b/components/StudentDialog/PaymentModal.tsx
@@ -11,6 +11,7 @@ import { collection, addDoc, Timestamp } from 'firebase/firestore'
 import { getAuth } from 'firebase/auth'
 import { db } from '../../lib/firebase'
 import { PATHS, logPath } from '../../lib/paths'
+import { Z_INDEX } from '../../lib/zindex'
 
 export default function PaymentModal({
   abbr,
@@ -48,8 +49,8 @@ export default function PaymentModal({
       fullWidth
       maxWidth="xs"
       slotProps={{
-        backdrop: { sx: { zIndex: 1600 } },
-        paper: { sx: { zIndex: 1601 } },
+        backdrop: { sx: { zIndex: Z_INDEX.dialogBackdrop } },
+        paper: { sx: { zIndex: Z_INDEX.dialog } },
       }}
     >
       <DialogTitle sx={{ fontFamily: 'Cantata One' }}>Add Payment</DialogTitle>

--- a/components/StudentDialog/RateModal.tsx
+++ b/components/StudentDialog/RateModal.tsx
@@ -11,9 +11,13 @@ import { collection, doc, getDocs, setDoc, Timestamp } from 'firebase/firestore'
 import { getAuth } from 'firebase/auth'
 import { db } from '../../lib/firebase'
 import { PATHS, logPath } from '../../lib/paths'
+import { useBillingClient, billingKey } from '../../lib/billing/useBilling'
+import { writeSummaryFromCache } from '../../lib/liveRefresh'
 
 interface RateModalProps {
   sessionId: string
+  abbr: string
+  account: string
   open: boolean
   onClose: () => void
   initialRate: string
@@ -22,12 +26,15 @@ interface RateModalProps {
 
 export default function RateModal({
   sessionId,
+  abbr,
+  account,
   open,
   onClose,
   initialRate,
   onSaved,
 }: RateModalProps) {
   const [amount, setAmount] = useState(initialRate)
+  const qc = useBillingClient()
 
   useEffect(() => {
     if (open) setAmount(initialRate)
@@ -48,6 +55,36 @@ export default function RateModal({
       editedBy: getAuth().currentUser?.email || 'system',
     })
     onSaved(Number(amount) || 0)
+    qc.setQueryData(billingKey(abbr, account), (prev?: any) => {
+      if (!prev) return prev
+      const rows = prev.rows.map((r: any) =>
+        r.id === sessionId
+          ? {
+              ...r,
+              amountDue: Number(amount) || 0,
+              displayRate: new Intl.NumberFormat(undefined, {
+                style: 'currency',
+                currency: 'HKD',
+                currencyDisplay: 'code',
+              }).format(Number(amount) || 0),
+              flags: { ...r.flags, manualRate: true },
+            }
+          : r,
+      )
+      const old = prev.rows.find((r: any) => r.id === sessionId)
+      const delta = (Number(amount) || 0) - (old?.amountDue || 0)
+      const affectsBalance =
+        !!old &&
+        !old.flags.cancelled &&
+        !old.flags.voucherUsed &&
+        !old.flags.inRetainer &&
+        !old.assignedPaymentId
+      const balanceDue = affectsBalance
+        ? Math.max(0, (prev.balanceDue || 0) + delta)
+        : prev.balanceDue || 0
+      return { ...prev, rows, balanceDue }
+    })
+    await writeSummaryFromCache(qc, abbr, account)
   }
 
   return (

--- a/components/StudentDialog/RateModal.tsx
+++ b/components/StudentDialog/RateModal.tsx
@@ -13,6 +13,8 @@ import { db } from '../../lib/firebase'
 import { PATHS, logPath } from '../../lib/paths'
 import { useBillingClient, billingKey } from '../../lib/billing/useBilling'
 import { writeSummaryFromCache } from '../../lib/liveRefresh'
+import { computeStudentSummary, writeStudentSummary } from '../../lib/studentSummary'
+import { Z_INDEX } from '../../lib/zindex'
 
 interface RateModalProps {
   sessionId: string
@@ -85,6 +87,8 @@ export default function RateModal({
       return { ...prev, rows, balanceDue }
     })
     await writeSummaryFromCache(qc, abbr, account)
+    const summary = await computeStudentSummary(abbr, account)
+    await writeStudentSummary(abbr, summary)
   }
 
   return (
@@ -94,8 +98,8 @@ export default function RateModal({
       fullWidth
       maxWidth="xs"
       slotProps={{
-        backdrop: { sx: { zIndex: 1600 } },
-        paper: { sx: { zIndex: 1601 } },
+        backdrop: { sx: { zIndex: Z_INDEX.dialogBackdrop } },
+        paper: { sx: { zIndex: Z_INDEX.dialog } },
       }}
     >
       <DialogTitle sx={{ fontFamily: 'Cantata One' }}>Edit Rate Charged</DialogTitle>

--- a/components/StudentDialog/RetainerModal.tsx
+++ b/components/StudentDialog/RetainerModal.tsx
@@ -3,6 +3,7 @@ import { Box, Button, TextField, Typography } from '@mui/material'
 import { addRetainer, calculateEndDate, RetainerDoc } from '../../lib/retainer'
 import { useBillingClient } from '../../lib/billing/useBilling'
 import { writeSummaryFromCache, markSessionsInRetainer } from '../../lib/liveRefresh'
+import { computeStudentSummary, writeStudentSummary } from '../../lib/studentSummary'
 
 const formatDate = (d: Date | null) =>
   d
@@ -58,6 +59,8 @@ export default function RetainerModal({
       const endMs = endDate ? endDate.getTime() : startMs
       markSessionsInRetainer(qc, abbr, account, startMs, endMs, true)
       await writeSummaryFromCache(qc, abbr, account)
+      const summary = await computeStudentSummary(abbr, account)
+      await writeStudentSummary(abbr, summary)
       onClose(true)
     } catch (e: any) {
       setError(String(e.message || e))

--- a/components/StudentDialog/RetainerModal.tsx
+++ b/components/StudentDialog/RetainerModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
 import { addRetainer, calculateEndDate, RetainerDoc } from '../../lib/retainer'
+import { useBillingClient } from '../../lib/billing/useBilling'
+import { writeSummaryFromCache, markSessionsInRetainer } from '../../lib/liveRefresh'
 
 const formatDate = (d: Date | null) =>
   d
@@ -13,12 +15,14 @@ const formatDate = (d: Date | null) =>
 
 export default function RetainerModal({
   abbr,
+  account,
   balanceDue,
   retainer,
   nextStart,
   onClose,
 }: {
   abbr: string
+  account: string
   balanceDue: number
   retainer?: RetainerDoc & { id: string }
   nextStart?: Date
@@ -38,23 +42,22 @@ export default function RetainerModal({
   )
   const [error, setError] = useState<string>('')
   const [saving, setSaving] = useState(false)
+  const qc = useBillingClient()
 
   const startDate = start ? new Date(start) : null
   const endDate = startDate ? calculateEndDate(startDate) : null
 
   const handleSave = async () => {
     if (!startDate || !rate) return
-    const numRate = Number(rate)
-    if (numRate > balanceDue) {
-      setError(
-        'Insufficient balance to add retainer. Please record a payment first.',
-      )
-      return
-    }
-    setError('')
-    setSaving(true)
-    try {
-      await addRetainer(abbr, startDate, numRate)
+      const numRate = Number(rate)
+      setError('')
+      setSaving(true)
+      try {
+        await addRetainer(abbr, startDate, numRate)
+      const startMs = startDate.getTime()
+      const endMs = endDate ? endDate.getTime() : startMs
+      markSessionsInRetainer(qc, abbr, account, startMs, endMs, true)
+      await writeSummaryFromCache(qc, abbr, account)
       onClose(true)
     } catch (e: any) {
       setError(String(e.message || e))
@@ -118,9 +121,12 @@ export default function RetainerModal({
           type="number"
           fullWidth
           sx={{ mb: 1 }}
-          InputLabelProps={{ shrink: true, sx: { fontFamily: 'Newsreader', fontWeight: 200 } }}
+          InputLabelProps={{
+            shrink: true,
+            sx: { fontFamily: 'Newsreader', fontWeight: 200 },
+          }}
           inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
-          helperText={`Balance Due: ${new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD', currencyDisplay: 'code' }).format(balanceDue)}`}
+          helperText={`Balance Due: ${new Intl.NumberFormat(undefined, { style: 'currency', currency: 'HKD', currencyDisplay: 'code' }).format(balanceDue)} (retainers can be added even if balance is insufficient)`}
           FormHelperTextProps={{ sx: { fontFamily: 'Newsreader', fontWeight: 500 } }}
         />
         {error && (

--- a/components/StudentDialog/RetainersTab.tsx
+++ b/components/StudentDialog/RetainersTab.tsx
@@ -39,9 +39,11 @@ interface RetRow extends RetainerDoc {
 
 export default function RetainersTab({
   abbr,
+  account,
   balanceDue,
 }: {
   abbr: string
+  account: string
   balanceDue: number
 }) {
   const [rows, setRows] = useState<RetRow[]>([])
@@ -201,6 +203,7 @@ export default function RetainersTab({
       {modal.open && (
         <RetainerModal
           abbr={abbr}
+          account={account}
           balanceDue={balanceDue}
           retainer={modal.retainer}
           nextStart={modal.nextStart}

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -5,6 +5,8 @@ import RateModal from './RateModal'
 import { collection, doc, getDocs, setDoc, Timestamp } from 'firebase/firestore'
 import { getAuth } from 'firebase/auth'
 import { db } from '../../lib/firebase'
+import { useBillingClient, billingKey } from '../../lib/billing/useBilling'
+import { writeSummaryFromCache } from '../../lib/liveRefresh'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, {
@@ -24,15 +26,23 @@ const formatDate = (s: string) => {
 }
 
 interface SessionDetailProps {
+  abbr: string
+  account: string
   session: any
   onBack: () => void
 }
 
 // SessionDetail shows information for a single session. Limited editing, such
 // as rate charged, occurs here rather than inline in the sessions table.
-export default function SessionDetail({ session, onBack }: SessionDetailProps) {
+export default function SessionDetail({
+  abbr,
+  account,
+  session,
+  onBack,
+}: SessionDetailProps) {
   const [voucherUsed, setVoucherUsed] = useState(!!session.voucherUsed)
   const [rateOpen, setRateOpen] = useState(false)
+  const qc = useBillingClient()
 
   const createVoucherEntry = async (free: boolean) => {
     const path = PATHS.sessionVoucher(session.id)
@@ -51,6 +61,29 @@ export default function SessionDetail({ session, onBack }: SessionDetailProps) {
     })
     setVoucherUsed(free)
     session.voucherUsed = free
+    qc.setQueryData(billingKey(abbr, account), (prev?: any) => {
+      if (!prev) return prev
+      const rows = prev.rows.map((r: any) =>
+        r.id === session.id
+          ? { ...r, flags: { ...r.flags, voucherUsed: free } }
+          : r,
+      )
+      const old = prev.rows.find((r: any) => r.id === session.id)
+      let balanceDue = prev.balanceDue || 0
+      if (
+        old &&
+        !old.flags.cancelled &&
+        !old.flags.inRetainer &&
+        !old.assignedPaymentId
+      ) {
+        const amt = old.amountDue || 0
+        balanceDue = free
+          ? Math.max(0, balanceDue - amt)
+          : balanceDue + amt
+      }
+      return { ...prev, rows, balanceDue }
+    })
+    await writeSummaryFromCache(qc, abbr, account)
   }
 
   const markVoucher = async () => {
@@ -198,6 +231,8 @@ export default function SessionDetail({ session, onBack }: SessionDetailProps) {
         </Typography>
         <RateModal
           sessionId={session.id}
+          abbr={abbr}
+          account={account}
           open={rateOpen}
           onClose={() => setRateOpen(false)}
           initialRate={

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -7,6 +7,7 @@ import { getAuth } from 'firebase/auth'
 import { db } from '../../lib/firebase'
 import { useBillingClient, billingKey } from '../../lib/billing/useBilling'
 import { writeSummaryFromCache } from '../../lib/liveRefresh'
+import { computeStudentSummary, writeStudentSummary } from '../../lib/studentSummary'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, {
@@ -84,6 +85,8 @@ export default function SessionDetail({
       return { ...prev, rows, balanceDue }
     })
     await writeSummaryFromCache(qc, abbr, account)
+    const summary = await computeStudentSummary(abbr, account)
+    await writeStudentSummary(abbr, summary)
   }
 
   const markVoucher = async () => {

--- a/components/StudentDialog/VoucherModal.tsx
+++ b/components/StudentDialog/VoucherModal.tsx
@@ -12,6 +12,8 @@ import { db } from '../../lib/firebase'
 import { PATHS, logPath } from '../../lib/paths'
 import { useBillingClient, billingKey } from '../../lib/billing/useBilling'
 import { writeSummaryFromCache } from '../../lib/liveRefresh'
+import { computeStudentSummary, writeStudentSummary } from '../../lib/studentSummary'
+import { Z_INDEX } from '../../lib/zindex'
 
 export default function VoucherModal({
   abbr,
@@ -52,6 +54,8 @@ export default function VoucherModal({
       }
     })
     await writeSummaryFromCache(qc, abbr, account)
+    const summary = await computeStudentSummary(abbr, account)
+    await writeStudentSummary(abbr, summary)
   }
 
   return (
@@ -61,9 +65,9 @@ export default function VoucherModal({
       fullWidth
       maxWidth="xs"
       slotProps={{
-        root: { sx: { zIndex: 1600 } },
-        backdrop: { sx: { zIndex: 1600 } },
-        paper: { sx: { zIndex: 1601 } },
+        root: { sx: { zIndex: Z_INDEX.dialogBackdrop } },
+        backdrop: { sx: { zIndex: Z_INDEX.dialogBackdrop } },
+        paper: { sx: { zIndex: Z_INDEX.dialog } },
       }}
     >
       <DialogTitle sx={{ fontFamily: 'Cantata One' }}>

--- a/components/StudentDialog/VouchersTab.tsx
+++ b/components/StudentDialog/VouchersTab.tsx
@@ -39,7 +39,7 @@ interface Row {
   EditedBy?: string
 }
 
-export default function VouchersTab({ abbr }: { abbr: string }) {
+export default function VouchersTab({ abbr, account }: { abbr: string; account: string }) {
   const [rows, setRows] = useState<Row[]>([])
   const [modalOpen, setModalOpen] = useState(false)
 
@@ -122,6 +122,7 @@ export default function VouchersTab({ abbr }: { abbr: string }) {
       </Table>
       <VoucherModal
         abbr={abbr}
+        account={account}
         open={modalOpen}
         onClose={() => {
           setModalOpen(false)

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1,0 +1,46 @@
+# Development Guidelines
+
+## Principles
+- **Minimal DB caching**: Store only authoritative or user-entered data in Firestore. Derived values stay in code using React Query and compute functions.
+- **Single source of truth**: Billing and session values come from `lib/billing/compute.ts` via `useBilling(abbr, account)`. Lists in different tabs must display the same computed data.
+- **Live refresh only what changed**: After mutations, patch the relevant React Query cache and write a fresh `billingSummary` from the patched cache.
+- **Inline spinners, no overlays**: Each field handles its own loading state with small spinners. Do not block entire dialogs.
+
+## Mutation Pattern
+```ts
+await firestoreWrite()
+patchCache()
+await writeSummaryFromCache(qc, abbr, account)
+// optional: debounced invalidateBilling(abbr, account, qc)
+```
+Example from assigning sessions:
+```ts
+patchBillingAssignedSessions(qc, abbr, account, selected)
+await writeSummaryFromCache(qc, abbr, account)
+```
+
+## Listener Pattern
+- Subscribe to the specific document being edited with `onSnapshot` when a modal opens.
+- Unsubscribe on close.
+- Do not add broad collection listeners.
+
+Example:
+```ts
+useEffect(() => {
+  const unsub = onSnapshot(doc(db, PATHS.payments(abbr), payment.id), snap => {
+    const data = snap.data()
+    if (data) {
+      setRemaining(data.remainingAmount ?? Number(data.amount) ?? 0)
+      payment.assignedSessions = data.assignedSessions
+    }
+  })
+  return () => unsub()
+}, [abbr, payment.id])
+```
+
+## Single Source of Truth
+Always use `useBilling(abbr, account)` for any session or billing display. Patch its cache rather than keeping duplicate state.
+
+## Do Not Persist Derived Data
+Only `billingSummary` (balanceDue, voucherBalance, updatedAt) is cached in Firestore. No other derived collections or summaries should be written.
+

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -44,3 +44,14 @@ Always use `useBilling(abbr, account)` for any session or billing display. Patch
 ## Do Not Persist Derived Data
 Only `billingSummary` (balanceDue, voucherBalance, updatedAt) is cached in Firestore. No other derived collections or summaries should be written.
 
+## Student Summary Cache
+Selected session fields (`jointDate`, `lastSession`, `totalSessionsExCancelled`, `cancelledCount`) are cached under `Students/{abbr}.cached`.
+Use:
+
+```ts
+const summary = await computeStudentSummary(abbr, account)
+await writeStudentSummary(abbr, summary)
+```
+
+Run this after session-affecting mutations and on `SessionsTab` mount so card views stay in sync.
+

--- a/lib/billing/monthLabel.ts
+++ b/lib/billing/monthLabel.ts
@@ -1,0 +1,9 @@
+export function monthLabelFor(start: number | Date): string {
+  const d =
+    typeof start === 'number'
+      ? new Date(start)
+      : new Date(start.getTime())
+  if (d.getDate() >= 21) d.setMonth(d.getMonth() + 1)
+  return d.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+}
+

--- a/lib/billing/useBilling.ts
+++ b/lib/billing/useBilling.ts
@@ -5,11 +5,11 @@ import { db } from '../firebase'
 import { PATHS } from '../paths'
 import { buildContext, computeBilling, BillingResult } from './compute'
 
-export const billingKey = (abbr: string) => ['billing', abbr]
+export const billingKey = (abbr: string, account: string) => ['billing', abbr, account]
 
 export function useBilling(abbr: string, account: string) {
   return useQuery({
-    queryKey: billingKey(abbr),
+    queryKey: billingKey(abbr, account),
     queryFn: async () => {
       const ctx = await buildContext(abbr, account)
       return computeBilling(ctx)
@@ -22,19 +22,17 @@ export function useBilling(abbr: string, account: string) {
 export async function writeBillingSummary(abbr: string, result: BillingResult) {
   await setDoc(
     doc(db, PATHS.student(abbr)),
-    {
-      billingSummary: {
+    { billingSummary: {
         balanceDue: result.balanceDue,
         voucherBalance: result.voucherBalance,
         updatedAt: new Date(),
-      },
-    },
+      }},
     { merge: true }
   )
 }
 
-export function invalidateBilling(abbr: string, qc: QueryClient) {
-  return qc.invalidateQueries({ queryKey: billingKey(abbr) })
+export function invalidateBilling(abbr: string, account: string, qc: QueryClient) {
+  return qc.invalidateQueries({ queryKey: billingKey(abbr, account) })
 }
 
 export function useBillingClient() {

--- a/lib/gcal.ts
+++ b/lib/gcal.ts
@@ -1,16 +1,11 @@
-// lib/gcal.ts
-
-// Placeholder Google Calendar logging utilities.
-// Auto-mode stubs a background watcher; manual mode scans recent events.
-
 export async function scanGoogleCalendar() {
-  // TODO: integrate with Google Calendar API and persist session logs.
-  console.log('Scanning Google Calendar (stub)')
-  return { added: 0 }
+  const res = await fetch('/api/gcal/scan')
+  if (!res.ok) throw new Error('scan failed')
+  return res.json() as Promise<{ added?: number; updated?: number; skipped?: number }>
 }
 
 export function startGCalAutoLogging() {
-  // TODO: hook into Cloud Function or background worker.
-  console.log('Starting Google Calendar auto logging (stub)')
+  // Auto logging should be handled by a Cloud Function or external scheduler
+  // that periodically hits the /api/gcal/scan endpoint.
 }
 

--- a/lib/gcal.ts
+++ b/lib/gcal.ts
@@ -1,0 +1,16 @@
+// lib/gcal.ts
+
+// Placeholder Google Calendar logging utilities.
+// Auto-mode stubs a background watcher; manual mode scans recent events.
+
+export async function scanGoogleCalendar() {
+  // TODO: integrate with Google Calendar API and persist session logs.
+  console.log('Scanning Google Calendar (stub)')
+  return { added: 0 }
+}
+
+export function startGCalAutoLogging() {
+  // TODO: hook into Cloud Function or background worker.
+  console.log('Starting Google Calendar auto logging (stub)')
+}
+

--- a/lib/liveRefresh.ts
+++ b/lib/liveRefresh.ts
@@ -1,0 +1,115 @@
+import { QueryClient } from '@tanstack/react-query'
+import { billingKey } from './billing/useBilling'
+import type { BillingResult } from './billing/compute'
+import { writeBillingSummary } from './billing/useBilling'
+import { monthLabelFor } from './billing/monthLabel'
+
+export function patchBillingAssignedSessions(
+  qc: QueryClient,
+  abbr: string,
+  account: string,
+  addedSessionIds: string[],
+  removedSessionIds: string[] = []
+) {
+  qc.setQueryData(billingKey(abbr, account), (prev?: BillingResult) => {
+    if (!prev) return prev
+    const addSet = new Set(addedSessionIds)
+    const remSet = new Set(removedSessionIds)
+    let balanceDue = prev.balanceDue || 0
+    const rows = prev.rows.map((r) => {
+      if (addSet.has(r.id) && !r.assignedPaymentId) {
+        balanceDue -= r.amountDue || 0
+        return { ...r, assignedPaymentId: 'assigned' }
+      }
+      if (remSet.has(r.id) && r.assignedPaymentId) {
+        balanceDue += r.amountDue || 0
+        return { ...r, assignedPaymentId: null }
+      }
+      return r
+    })
+    return { ...prev, rows, balanceDue: Math.max(0, balanceDue) }
+  })
+}
+
+export function upsertUnpaidRetainerRow(
+  qc: QueryClient,
+  abbr: string,
+  account: string,
+  retainerId: string,
+  startMs: number,
+  endMs: number,
+  rate: number,
+  unpaid: boolean,
+) {
+  const monthLabel = monthLabelFor(startMs)
+  qc.setQueryData(billingKey(abbr, account), (prev?: BillingResult) => {
+    if (!prev) return prev
+    let balanceDue = prev.balanceDue || 0
+    let unpaidRetainers = prev.unpaidRetainers
+    const exists = unpaidRetainers.find((r) => r.id === retainerId)
+    if (unpaid && !exists) {
+      unpaidRetainers = [...unpaidRetainers, { id: retainerId, monthLabel, rate }]
+      balanceDue += rate
+    }
+    if (!unpaid && exists) {
+      unpaidRetainers = unpaidRetainers.filter((r) => r.id !== retainerId)
+      balanceDue = Math.max(0, balanceDue - (exists?.rate || 0))
+    }
+    return { ...prev, unpaidRetainers, balanceDue }
+  })
+}
+
+export function markSessionsInRetainer(
+  qc: QueryClient,
+  abbr: string,
+  account: string,
+  startMs: number,
+  endMs: number,
+  inRetainer: boolean,
+) {
+  qc.setQueryData(billingKey(abbr, account), (prev?: BillingResult) => {
+    if (!prev) return prev
+    let balanceDue = prev.balanceDue || 0
+    const rows = prev.rows.map((r) => {
+      if (r.startMs >= startMs && r.startMs <= endMs) {
+        if (!r.flags.cancelled && !r.flags.voucherUsed && !r.assignedPaymentId) {
+          balanceDue += inRetainer ? -(r.amountDue || 0) : r.flags.inRetainer ? r.amountDue || 0 : 0
+        }
+        return { ...r, flags: { ...r.flags, inRetainer } }
+      }
+      return r
+    })
+    return { ...prev, rows, balanceDue: Math.max(0, balanceDue) }
+  })
+}
+
+export function payRetainerPatch(
+  qc: QueryClient,
+  abbr: string,
+  account: string,
+  retainerId: string,
+) {
+  qc.setQueryData(billingKey(abbr, account), (prev?: BillingResult) => {
+    if (!prev) return prev
+    const unpaid = prev.unpaidRetainers
+    const found = unpaid.find((r) => r.id === retainerId)
+    if (!found) return prev
+    const unpaidRetainers = unpaid.filter((r) => r.id !== retainerId)
+    const balanceDue = Math.max(0, (prev.balanceDue || 0) - (found.rate || 0))
+    return { ...prev, unpaidRetainers, balanceDue }
+  })
+}
+
+export async function writeSummaryFromCache(
+  qc: QueryClient,
+  abbr: string,
+  account: string
+) {
+  const cached = qc.getQueryData(billingKey(abbr, account)) as
+    | BillingResult
+    | undefined
+  if (cached) {
+    await writeBillingSummary(abbr, cached)
+  }
+}
+

--- a/lib/studentSummary.ts
+++ b/lib/studentSummary.ts
@@ -1,0 +1,44 @@
+import { doc, setDoc } from 'firebase/firestore'
+import { db } from './firebase'
+import { PATHS } from './paths'
+import { buildContext, computeBilling } from './billing/compute'
+
+export interface StudentSummary {
+  jointDateISO: string | null
+  lastSessionISO: string | null
+  totalSessionsExCancelled: number
+  cancelledCount: number
+}
+
+export async function computeStudentSummary(abbr: string, account: string): Promise<StudentSummary> {
+  const ctx = await buildContext(abbr, account)
+  const res = computeBilling(ctx)
+  const rows = res.rows
+  const sorted = rows.slice().sort((a, b) => a.startMs - b.startMs)
+  const joint = sorted[0]?.startMs
+  const nonCancelled = rows.filter((r) => !r.flags.cancelled)
+  const last = nonCancelled.length ? Math.max(...nonCancelled.map((r) => r.startMs)) : undefined
+  return {
+    jointDateISO: joint ? new Date(joint).toISOString() : null,
+    lastSessionISO: last ? new Date(last).toISOString() : null,
+    totalSessionsExCancelled: nonCancelled.length,
+    cancelledCount: rows.length - nonCancelled.length,
+  }
+}
+
+export async function writeStudentSummary(abbr: string, summary: StudentSummary) {
+  await setDoc(
+    doc(db, PATHS.student(abbr)),
+    {
+      cached: {
+        jointDate: summary.jointDateISO,
+        lastSession: summary.lastSessionISO,
+        totalSessionsExCancelled: summary.totalSessionsExCancelled,
+        cancelledCount: summary.cancelledCount,
+        updatedAt: new Date().toISOString(),
+      },
+    },
+    { merge: true },
+  )
+}
+

--- a/lib/zindex.ts
+++ b/lib/zindex.ts
@@ -1,0 +1,7 @@
+export const Z_INDEX = {
+  floatingWindow: 1500,
+  dialogBackdrop: 1600,
+  dialog: 1601,
+  menu: 1700,
+} as const
+

--- a/pages/api/gcal/scan.ts
+++ b/pages/api/gcal/scan.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { google } from 'googleapis'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).end()
+    return
+  }
+  try {
+    const email = process.env.GCAL_CLIENT_EMAIL
+    const key = (process.env.GCAL_PRIVATE_KEY || '').replace(/\\n/g, '\n')
+    const calendarIds = (process.env.GOOGLE_CALENDAR_ID || '').split(',').filter(Boolean)
+    if (!email || !key || calendarIds.length === 0) {
+      res.status(500).json({ error: 'missing calendar credentials' })
+      return
+    }
+    const auth = new google.auth.JWT({
+      email,
+      key,
+      scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+    })
+    const calendar = google.calendar({ version: 'v3', auth })
+    const timeMin = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+    let added = 0
+    let updated = 0
+    let skipped = 0
+    for (const id of calendarIds) {
+      const resp = await calendar.events.list({ calendarId: id, timeMin })
+      const events = resp.data.items || []
+      events.forEach(() => {
+        skipped += 1
+      })
+    }
+    res.status(200).json({ added, updated, skipped })
+  } catch (e) {
+    console.error(e)
+    res.status(500).json({ error: 'scan failed' })
+  }
+}
+

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -1,7 +1,7 @@
 // pages/dashboard/businesses/coaching-sessions.tsx
 
 import React, { useEffect, useState } from 'react'
-import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore'
+import { collection, getDocs, onSnapshot, doc } from 'firebase/firestore'
 import SidebarLayout from '../../../components/SidebarLayout'
 import { db } from '../../../lib/firebase'
 import {
@@ -17,24 +17,19 @@ import {
   MenuItem,
   Snackbar,
 } from '@mui/material'
+import { keyframes } from '@mui/system'
 import { PATHS, logPath } from '../../../lib/paths'
 import OverviewTab from '../../../components/StudentDialog/OverviewTab'
 import SessionDetail from '../../../components/StudentDialog/SessionDetail'
 import FloatingWindow from '../../../components/StudentDialog/FloatingWindow'
 import { clearSessionSummaries } from '../../../lib/sessionStats'
 import BatchRenamePayments from '../../../tools/BatchRenamePayments'
-import { computeSessionStart } from '../../../lib/sessions'
-import { computeBalanceDue } from '../../../lib/billing/balance'
+import { useBilling } from '../../../lib/billing/useBilling'
+import { scanGoogleCalendar } from '../../../lib/gcal'
 
 interface StudentMeta {
   abbr: string
   account: string
-}
-interface StudentDetails extends StudentMeta {
-  sex?: string
-  balanceDue?: number
-  total: number
-  upcoming: number
 }
 
 const formatCurrency = (n: number) =>
@@ -44,11 +39,73 @@ const formatCurrency = (n: number) =>
     currencyDisplay: 'code',
   }).format(n)
 
+const blinkFade = keyframes`
+  0% {opacity:.4}
+  50% {opacity:1}
+  100% {opacity:.4}
+`
+
+const blinkSx = { animation: `${blinkFade} 1.2s ease-in-out infinite` }
+
+function StudentCard({
+  abbr,
+  account,
+  onClick,
+}: {
+  abbr: string
+  account: string
+  onClick: () => void
+}) {
+  const { data: bill } = useBilling(abbr, account)
+  const [sex, setSex] = useState<string | undefined>()
+  const [balanceDue, setBalanceDue] = useState<number | undefined>()
+
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, PATHS.student(abbr)), (snap) => {
+      const data = snap.data() as any
+      setSex(data?.sex)
+      setBalanceDue(data?.billingSummary?.balanceDue)
+    })
+    return () => unsub()
+  }, [abbr])
+
+  const rows = bill?.rows || []
+  const totalNonCancelled = rows.filter((r) => !r.flags.cancelled).length
+  const upcoming = rows.filter(
+    (r) => !r.flags.cancelled && r.startMs > Date.now(),
+  ).length
+
+  return (
+    <Card>
+      <CardActionArea onClick={onClick}>
+        <CardContent>
+          <Typography variant="h6">{account}</Typography>
+          <Typography>
+            <Box component="span" sx={sex === undefined ? blinkSx : undefined}>
+              {sex ?? '–'}
+            </Box>{' '}
+            • Due:{' '}
+            <Box
+              component="span"
+              sx={balanceDue === undefined ? blinkSx : undefined}
+            >
+              {balanceDue !== undefined ? formatCurrency(balanceDue) : '–'}
+            </Box>
+          </Typography>
+          <Typography sx={!bill ? blinkSx : undefined}>
+            Total: {bill ? totalNonCancelled : '–'}
+            {bill && upcoming > 0 ? ` → ${upcoming}` : ''}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}
+
 export default function CoachingSessions() {
-  const [students, setStudents] = useState<StudentDetails[]>([])
+  const [students, setStudents] = useState<StudentMeta[]>([])
   const [loading, setLoading] = useState(true)
-  const [loadingStatus, setLoadingStatus] = useState('')
-  const [selected, setSelected] = useState<StudentDetails | null>(null)
+  const [selected, setSelected] = useState<StudentMeta | null>(null)
   const [serviceMode, setServiceMode] = useState(false)
   const [toolsAnchor, setToolsAnchor] = useState<null | HTMLElement>(null)
   const [scanMessage, setScanMessage] = useState('')
@@ -72,87 +129,17 @@ export default function CoachingSessions() {
 
   useEffect(() => {
     let mounted = true
-
     async function loadAll() {
-      console.log('📥 loading students list')
       logPath('students', PATHS.students)
       const snap = await getDocs(collection(db, PATHS.students))
-      console.log(`   found ${snap.size} students`)
       const basics: StudentMeta[] = snap.docs.map((d) => ({
         abbr: d.id,
         account: (d.data() as any).account,
       }))
-
       if (!mounted) return
-      setStudents(basics.map((b) => ({ ...b, total: 0, upcoming: 0 })))
-
-      const totalCount = basics.length
-      await Promise.all(
-        basics.map(async (b, i) => {
-          const latest = async (col: string) => {
-            const path = `${PATHS.student(b.abbr)}/${col}`
-            logPath('studentSub', path)
-            const snap = await getDocs(
-              query(
-                collection(db, path),
-                orderBy('timestamp', 'desc'),
-                limit(1)
-              )
-            )
-            if (snap.empty) {
-              return undefined
-            }
-            return (snap.docs[0].data() as any)[col]
-          }
-
-          const [firstName, lastName] = await Promise.all([
-            latest('firstName'),
-            latest('lastName'),
-          ])
-          if (!mounted) return
-          setLoadingStatus(
-            `${firstName || b.account || b.abbr} ${lastName || ''} - (${i + 1} of ${totalCount})`
-          )
-
-          const [sex, balanceDue, sessSnap] = await Promise.all([
-            latest('sex'),
-            computeBalanceDue(b.abbr, b.account),
-            (async () => {
-              logPath('sessionsQuery', PATHS.sessions)
-              return getDocs(
-                query(
-                  collection(db, PATHS.sessions),
-                  where('sessionName', '==', b.account),
-                ),
-              )
-            })(),
-          ])
-
-          const starts = await Promise.all(
-            sessSnap.docs.map((sd) => computeSessionStart(sd.id, sd.data() as any)),
-          )
-          const total = sessSnap.size
-          const now = new Date()
-          let upcoming = 0
-          starts.forEach((d) => {
-            if (d && d > now) upcoming++
-          })
-
-          if (!mounted) return
-          setStudents((prev) =>
-            prev.map((s) =>
-              s.abbr === b.abbr
-                ? { ...s, sex, balanceDue, total, upcoming }
-                : s,
-            ),
-          )
-        })
-      )
-
-      if (!mounted) return
+      setStudents(basics)
       setLoading(false)
     }
-
     loadAll().catch(console.error)
     return () => {
       mounted = false
@@ -163,59 +150,51 @@ export default function CoachingSessions() {
     <SidebarLayout>
       {loading && (
         <Box sx={{ width: '100%' }}>
-          <Typography align="center" sx={{ mb: 1 }}>
-            {loadingStatus}
-          </Typography>
           <LinearProgress />
-          <Typography align="center" sx={{ mt: 1 }}>
-            Loading student cards…
-          </Typography>
         </Box>
       )}
 
-      {!loading && (
-        <Box sx={{ position: 'relative', pb: 8 }}>
-          <Grid container spacing={2} sx={{ mt: 2 }}>
-            {students.map((s) => (
-              <Grid item key={s.abbr} xs={12} sm={6} md={4}>
-                <Card>
-                  <CardActionArea onClick={() => setSelected(s)}>
-                    <CardContent>
-                      <Typography variant="h6">{s.account}</Typography>
-                      <Typography>
-                        {s.sex ?? '–'} • Due: {formatCurrency(s.balanceDue ?? 0)}
-                      </Typography>
-                      <Typography>
-                        Total: {s.total}
-                        {s.upcoming > 0 ? ` → ${s.upcoming}` : ''}
-                      </Typography>
-                    </CardContent>
-                  </CardActionArea>
-                </Card>
-              </Grid>
-            ))}
-          </Grid>
-          <Menu
-            anchorEl={toolsAnchor}
-            open={Boolean(toolsAnchor)}
-            onClose={closeToolsMenu}
-            anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-            transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      <Box sx={{ position: 'relative', pb: 8 }}>
+        <Grid container spacing={2} sx={{ mt: 2 }}>
+          {students.map((s) => (
+            <Grid item key={s.abbr} xs={12} sm={6} md={4}>
+              <StudentCard
+                abbr={s.abbr}
+                account={s.account}
+                onClick={() => setSelected(s)}
+              />
+            </Grid>
+          ))}
+        </Grid>
+        <Menu
+          anchorEl={toolsAnchor}
+          open={Boolean(toolsAnchor)}
+          onClose={closeToolsMenu}
+          anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        >
+          <MenuItem onClick={handleClearAll}>
+            🗑️ Clear All Session Summaries
+          </MenuItem>
+          <MenuItem
+            onClick={async () => {
+              closeToolsMenu()
+              const res = await scanGoogleCalendar()
+              setScanMessage(`Scanned ${res.added ?? 0} events`)
+            }}
           >
-            <MenuItem onClick={handleClearAll}>
-              🗑️ Clear All Session Summaries
-            </MenuItem>
-            <MenuItem
-              onClick={() => {
-                closeToolsMenu()
-                setRenameOpen(true)
-              }}
-            >
-              🏷️ Batch Rename Payments
-            </MenuItem>
-          </Menu>
-        </Box>
-      )}
+            📅 Scan Google Calendar
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              closeToolsMenu()
+              setRenameOpen(true)
+            }}
+          >
+            🏷️ Batch Rename Payments
+          </MenuItem>
+        </Menu>
+      </Box>
 
       {selected && (
         <OverviewTab
@@ -231,7 +210,7 @@ export default function CoachingSessions() {
       {detached && (
         <FloatingWindow
           title={`${detached.account} - #${detached.number} | ${new Date(
-            detached.startMs
+            detached.startMs,
           ).toLocaleDateString(undefined, {
             month: 'short',
             day: '2-digit',
@@ -239,7 +218,12 @@ export default function CoachingSessions() {
           })} ${detached.time}`}
           onClose={() => setDetached(null)}
         >
-          <SessionDetail session={detached} onBack={() => setDetached(null)} />
+          <SessionDetail
+            abbr={detached.abbr}
+            account={detached.account}
+            session={detached}
+            onBack={() => setDetached(null)}
+          />
         </FloatingWindow>
       )}
 
@@ -282,3 +266,4 @@ export default function CoachingSessions() {
     </SidebarLayout>
   )
 }
+

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -45,7 +45,13 @@ const blinkFade = keyframes`
   100% {opacity:.4}
 `
 
-const blinkSx = { animation: `${blinkFade} 1.2s ease-in-out infinite` }
+const blinkSx = {
+  animation: `${blinkFade} 1.2s ease-in-out infinite`,
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none',
+    opacity: 0.4,
+  },
+}
 
 function StudentCard({
   abbr,
@@ -179,8 +185,14 @@ export default function CoachingSessions() {
           <MenuItem
             onClick={async () => {
               closeToolsMenu()
-              const res = await scanGoogleCalendar()
-              setScanMessage(`Scanned ${res.added ?? 0} events`)
+              try {
+                const res = await scanGoogleCalendar()
+                setScanMessage(
+                  `Added ${res.added || 0}, updated ${res.updated || 0}, skipped ${res.skipped || 0}`,
+                )
+              } catch (e) {
+                setScanMessage('Google Calendar scan failed')
+              }
             }}
           >
             📅 Scan Google Calendar

--- a/pages/invoices/index.tsx
+++ b/pages/invoices/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export default function InvoicesPage() {
+  return <div>Invoices coming soon.</div>
+}
+

--- a/types/invoice.ts
+++ b/types/invoice.ts
@@ -1,0 +1,15 @@
+export interface InvoiceItem {
+  description: string
+  amount: number
+}
+
+export interface Invoice {
+  id: string
+  studentAbbr: string
+  account: string
+  items: InvoiceItem[]
+  total: number
+  issuedOn: Date
+  paid?: boolean
+}
+


### PR DESCRIPTION
## Summary
- tighten payment modal props by dropping unused account parameter
- require `unpaidRetainers` in billing results and share a month label helper across compute and cache patches
- unify retainer cache patches with shared month labels and remove fallback arrays
- track assigned sessions in local state and show live remaining amount to prevent over-assignment
- note that retainers can be added even when balance due is insufficient
- render coaching-session cards immediately with blinking placeholders and live student doc listeners
- hide voucher column by default with persistent column toggles and show session totals with cancelled counts
- stub Google Calendar scan utilities and invoice scaffolding for future billing integrations

## Testing
- `npm install`
- `npm run build`
- `CI=1 npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689c2b829af483239e3573309386581c