### PR TITLE
feat: add calendar sync script and endpoint

### DIFF
--- a/apps-script/CONFIG.gs
+++ b/apps-script/CONFIG.gs
@@ -1,0 +1,12 @@
+/**
+ * Configuration for Calendar sync.
+ * Replace placeholder values with actual IDs before deployment.
+ */
+var CONFIG = {
+  COACHING_CALENDAR_ID: 'REPLACE_WITH_CALENDAR_ID',
+  FIRESTORE_PROJECT_ID: 'REPLACE_WITH_PROJECT_ID',
+  FIRESTORE_DB: '(default)',
+  BACKFILL_DAYS: 365,
+  TIMEZONE: 'America/New_York',
+  SYNC_TOKEN_KEY: 'calendarSyncToken'
+};

--- a/apps-script/Firestore.gs
+++ b/apps-script/Firestore.gs
@@ -1,0 +1,90 @@
+/**
+ * Firestore helper functions for Apps Script (ES5).
+ */
+function getFirestoreToken_() {
+  return ScriptApp.getOAuthToken();
+}
+
+function getFirestoreUrl(path) {
+  var base = 'https://firestore.googleapis.com/v1/projects/' + CONFIG.FIRESTORE_PROJECT_ID + '/databases/' + encodeURIComponent(CONFIG.FIRESTORE_DB) + '/documents';
+  if (path && path.charAt(0) !== '/') path = '/' + path;
+  return base + path;
+}
+
+function writeFirestoreDoc(path, data) {
+  var url = getFirestoreUrl(path);
+  var payload = JSON.stringify({ fields: toFirestoreFields(data) });
+  var resp = UrlFetchApp.fetch(url, {
+    method: 'post',
+    headers: {
+      Authorization: 'Bearer ' + getFirestoreToken_(),
+      'Content-Type': 'application/json',
+      'X-HTTP-Method-Override': 'PATCH'
+    },
+    payload: payload,
+    muteHttpExceptions: true
+  });
+  if (resp.getResponseCode() >= 400) {
+    Logger.log('Firestore write error %s: %s', path, resp.getContentText().substring(0, 1000));
+  }
+  return resp;
+}
+
+function getDocument_(path) {
+  var url = getFirestoreUrl(path);
+  var resp = UrlFetchApp.fetch(url, {
+    headers: { Authorization: 'Bearer ' + getFirestoreToken_() },
+    muteHttpExceptions: true
+  });
+  if (resp.getResponseCode() === 404) {
+    return null;
+  }
+  return JSON.parse(resp.getContentText());
+}
+
+function runQuery_(structuredQuery) {
+  var url = getFirestoreUrl(':runQuery');
+  var resp = UrlFetchApp.fetch(url, {
+    method: 'post',
+    headers: {
+      Authorization: 'Bearer ' + getFirestoreToken_(),
+      'Content-Type': 'application/json'
+    },
+    payload: JSON.stringify({ structuredQuery: structuredQuery }),
+    muteHttpExceptions: true
+  });
+  return JSON.parse(resp.getContentText());
+}
+
+function toFirestoreFields(obj) {
+  var fields = {};
+  for (var key in obj) {
+    var val = obj[key];
+    if (val === null || val === undefined) continue;
+    if (Object.prototype.toString.call(val) === '[object Date]') {
+      fields[key] = { timestampValue: val.toISOString() };
+    } else if (typeof val === 'string') {
+      fields[key] = { stringValue: val };
+    } else if (typeof val === 'number') {
+      if (Math.floor(val) === val) {
+        fields[key] = { integerValue: String(val) };
+      } else {
+        fields[key] = { doubleValue: val };
+      }
+    } else if (typeof val === 'boolean') {
+      fields[key] = { booleanValue: val };
+    } else if (Object.prototype.toString.call(val) === '[object Array]') {
+      var arr = [];
+      for (var i = 0; i < val.length; i++) {
+        var v = val[i];
+        if (typeof v === 'string') {
+          arr.push({ stringValue: v });
+        }
+      }
+      fields[key] = { arrayValue: { values: arr } };
+    } else if (typeof val === 'object') {
+      fields[key] = { mapValue: { fields: toFirestoreFields(val) } };
+    }
+  }
+  return fields;
+}

--- a/apps-script/ScanEndpoint.gs
+++ b/apps-script/ScanEndpoint.gs
@@ -1,0 +1,58 @@
+/**
+ * Web endpoint for triggering calendar scans.
+ */
+function doPost(e) {
+  var body = {};
+  try {
+    if (e && e.postData && e.postData.contents) {
+      body = JSON.parse(e.postData.contents);
+    }
+  } catch (err) {}
+  var action = body.action || 'scanAll';
+  if (action === 'scanOne') {
+    var account = body.account;
+    var daysBack = body.daysBack;
+    var daysForward = body.daysForward;
+    var result = scanAccountWindow_(account, daysBack, daysForward);
+    return ContentService.createTextOutput(JSON.stringify(result)).setMimeType(ContentService.MimeType.JSON);
+  } else {
+    if (body.forceFull) clearSyncToken();
+    var res = syncCalendarChanges();
+    return ContentService.createTextOutput(JSON.stringify(res)).setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+function doGet(e) {
+  return doPost(e);
+}
+
+function scanAccountWindow_(account, daysBack, daysForward) {
+  abbrCache = {};
+  var now = new Date();
+  var back = daysBack || 365;
+  var forward = daysForward || 90;
+  var params = {
+    timeMin: new Date(now.getTime() - back * 24 * 60 * 60 * 1000).toISOString(),
+    timeMax: new Date(now.getTime() + forward * 24 * 60 * 60 * 1000).toISOString(),
+    singleEvents: true,
+    orderBy: 'startTime'
+  };
+  var processed = {};
+  var pageToken;
+  do {
+    if (pageToken) params.pageToken = pageToken;
+    var resp = calendarListWithRetry_(CONFIG.COACHING_CALENDAR_ID, params);
+    var items = resp.items || [];
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      var parsed = parseAccountAndType_(item.summary);
+      if (!parsed.account || parsed.account !== account) continue;
+      var eventId = extractEventId(item);
+      if (!eventId || processed[eventId]) continue;
+      processed[eventId] = true;
+      handleCalendarItem_(eventId, item);
+    }
+    pageToken = resp.nextPageToken;
+  } while (pageToken);
+  return { processed: Object.keys(processed).length };
+}

--- a/apps-script/SessionSync.gs
+++ b/apps-script/SessionSync.gs
@@ -1,0 +1,186 @@
+/**
+ * Core sync logic for Calendar events into Firestore.
+ */
+var DAY_MS = 24 * 60 * 60 * 1000;
+
+function syncCalendarChanges() {
+  abbrCache = {};
+  var props = PropertiesService.getScriptProperties();
+  var processed = {};
+  var now = new Date();
+  var token = props.getProperty(CONFIG.SYNC_TOKEN_KEY);
+  var lastResponse = null;
+
+  while (true) {
+    var params = { singleEvents: true };
+    if (token) {
+      params.syncToken = token;
+    } else {
+      params.timeMin = new Date(now.getTime() - CONFIG.BACKFILL_DAYS * DAY_MS).toISOString();
+      params.timeMax = now.toISOString();
+      params.orderBy = 'updated';
+    }
+
+    var pageToken = null;
+    try {
+      do {
+        if (pageToken) params.pageToken = pageToken;
+        var response = calendarListWithRetry_(CONFIG.COACHING_CALENDAR_ID, params);
+        lastResponse = response;
+        var items = response.items || [];
+        for (var i = 0; i < items.length; i++) {
+          var item = items[i];
+          var eventId = extractEventId(item);
+          if (!eventId || processed[eventId]) continue;
+          processed[eventId] = true;
+          handleCalendarItem_(eventId, item);
+        }
+        pageToken = response.nextPageToken;
+      } while (pageToken);
+      break;
+    } catch (err) {
+      var msg = err && err.message ? err.message : '';
+      if (err && (err.code === 410 || err.code === 400 || msg.toLowerCase().indexOf('sync token') !== -1)) {
+        clearSyncToken();
+        token = null;
+        pageToken = null;
+        continue;
+      } else {
+        Logger.log('Calendar sync error: ' + msg);
+        break;
+      }
+    }
+  }
+
+  if (lastResponse && lastResponse.nextSyncToken) {
+    props.setProperty(CONFIG.SYNC_TOKEN_KEY, lastResponse.nextSyncToken);
+  }
+  return { processed: Object.keys(processed).length };
+}
+
+function handleCalendarItem_(eventId, item) {
+  if (!item || !item.summary) {
+    Logger.log('Skipping event %s with no title', eventId);
+    return;
+  }
+  item = createDummyEvent(item);
+  var parsed = parseAccountAndType_(item.summary);
+  var account = parsed.account;
+  if (!account) {
+    Logger.log('Skipping event %s missing account', eventId);
+    return;
+  }
+  var sessionType = parsed.sessionType;
+  if (item.status === 'cancelled') sessionType = 'cancelled';
+  var start = new Date(item.start.dateTime || item.start.date);
+  var end = new Date(item.end.dateTime || item.end.date);
+  var abbr = resolveAbbrByAccount_(account);
+
+  var encodedId = encodeURIComponent(eventId);
+  var docPath = 'Sessions/' + encodedId;
+  var existing = getDocument_(docPath);
+  var prevType = null;
+  var prevStart = null;
+  var prevEnd = null;
+  if (existing && existing.fields) {
+    if (existing.fields.sessionType && existing.fields.sessionType.stringValue)
+      prevType = existing.fields.sessionType.stringValue;
+    if (existing.fields.origStartTimestamp && existing.fields.origStartTimestamp.timestampValue)
+      prevStart = new Date(existing.fields.origStartTimestamp.timestampValue);
+    if (existing.fields.origEndTimestamp && existing.fields.origEndTimestamp.timestampValue)
+      prevEnd = new Date(existing.fields.origEndTimestamp.timestampValue);
+  }
+
+  var data = {
+    sessionName: account,
+    account: account,
+    abbr: abbr,
+    sessionType: sessionType,
+    origStartTimestamp: start,
+    origEndTimestamp: end,
+    updatedAt: new Date(),
+    source: 'calendar'
+  };
+  if (!existing) data.createdAt = new Date();
+  upsertSessionDoc_(docPath, data);
+
+  var historyType = null;
+  var historySessionType = sessionType;
+  var origStart = start;
+  var origEnd = end;
+  var newStart = null;
+  var newEnd = null;
+
+  if (item.status === 'cancelled') {
+    if (prevType !== 'cancelled') {
+      historyType = 'Deleted';
+      historySessionType = prevType || sessionType;
+      origStart = prevStart || start;
+      origEnd = prevEnd || end;
+    }
+  } else if (!existing) {
+    historyType = 'Created';
+  } else {
+    var changed = false;
+    if (prevType !== sessionType) changed = true;
+    if (!prevStart || prevStart.getTime() !== start.getTime()) changed = true;
+    if (!prevEnd || prevEnd.getTime() !== end.getTime()) changed = true;
+    if (changed) {
+      historyType = 'Changed';
+      origStart = prevStart || start;
+      origEnd = prevEnd || end;
+      newStart = start;
+      newEnd = end;
+    }
+  }
+
+  if (historyType) {
+    logEventHistory_(encodedId, {
+      type: historyType,
+      client: account,
+      sessionType: historySessionType,
+      origStartTimestamp: origStart,
+      origEndTimestamp: origEnd,
+      newStartTimestamp: newStart,
+      newEndTimestamp: newEnd
+    });
+  }
+}
+
+function calendarListWithRetry_(calendarId, params) {
+  var attempts = 0;
+  while (attempts < 5) {
+    try {
+      return Calendar.Events.list(calendarId, params);
+    } catch (err) {
+      attempts++;
+      if (attempts >= 5) throw err;
+      Utilities.sleep(8000);
+    }
+  }
+}
+
+function upsertSessionDoc_(path, data) {
+  writeFirestoreDoc(path, data);
+}
+
+function logEventHistory_(encodedEventId, entry) {
+  var now = new Date();
+  var times = formatTime(now);
+  entry.dateStamp = times.dateStamp;
+  entry.timeStamp = times.timeStamp;
+  entry.timestamp = now;
+  entry.changeTimestamp = now;
+  var historyId = Utilities.getUuid();
+  writeFirestoreDoc('Sessions/' + encodedEventId + '/AppointmentHistory/' + historyId, entry);
+}
+
+function auditAllEvents() {
+  clearSyncToken();
+  return syncCalendarChanges();
+}
+
+function clearSyncToken() {
+  PropertiesService.getScriptProperties().deleteProperty(CONFIG.SYNC_TOKEN_KEY);
+}
+

--- a/apps-script/Utils.gs
+++ b/apps-script/Utils.gs
@@ -1,0 +1,59 @@
+/**
+ * Utility helpers for Calendar syncing.
+ */
+var abbrCache = {};
+
+function formatTime(date) {
+  return {
+    dateStamp: Utilities.formatDate(date, CONFIG.TIMEZONE, 'yyyy-MM-dd'),
+    timeStamp: Utilities.formatDate(date, CONFIG.TIMEZONE, 'HH:mm:ss'),
+    timestamp: date.toISOString()
+  };
+}
+
+function extractEventId(item) {
+  if (item && item.id) return item.id.split('@')[0];
+  if (item && item.iCalUID) return item.iCalUID.split('@')[0];
+  return null;
+}
+
+function createDummyEvent(item) {
+  if (item && item.start && item.start.date && !item.start.dateTime) {
+    var start = new Date(item.start.date + 'T00:00:00');
+    var end = item.end && item.end.date ? new Date(item.end.date + 'T00:00:00') : new Date(start.getTime() + 24 * 60 * 60 * 1000);
+    item.start.dateTime = start.toISOString();
+    item.end.dateTime = end.toISOString();
+  }
+  return item;
+}
+
+function parseAccountAndType_(title) {
+  if (!title) return { account: null, sessionType: 'physical' };
+  var virtual = /\(FaceTime\)/i.test(title);
+  var account = title.replace(/\(FaceTime\)/i, '').trim();
+  return { account: account, sessionType: virtual ? 'virtual' : 'physical' };
+}
+
+function resolveAbbrByAccount_(account) {
+  if (!account) return null;
+  if (abbrCache[account]) return abbrCache[account];
+  var query = {
+    from: [{ collectionId: 'Students' }],
+    where: {
+      fieldFilter: {
+        field: { fieldPath: 'account' },
+        op: 'EQUAL',
+        value: { stringValue: account }
+      }
+    },
+    limit: 1
+  };
+  var resp = runQuery_(query);
+  var abbr = null;
+  if (resp && resp.length && resp[0].document) {
+    var parts = resp[0].document.name.split('/');
+    abbr = parts[parts.length - 1];
+  }
+  abbrCache[account] = abbr;
+  return abbr;
+}

--- a/pages/api/calendar-scan.ts
+++ b/pages/api/calendar-scan.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  try {
+    const url = process.env.CALENDAR_SCAN_URL;
+    if (!url) {
+      return res.status(500).json({ error: 'CALENDAR_SCAN_URL not configured' });
+    }
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body || { action: 'scanAll' }),
+    });
+    const data = await response.json();
+    return res.status(response.ok ? 200 : 500).json(data);
+  } catch (err: any) {
+    console.error('[api/calendar-scan] error', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- implement token-based incremental sync with retry and bounded full scan fallback
- log session history only when data changes and encode event IDs in Firestore paths
- enforce strict account filtering for targeted scans and encode Firestore numbers accurately

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d9a9cbc1c83239d8b5b8dd607ba44