### PR TITLE
feat: wire calendar scan tools and resizable tables

### DIFF
--- a/apps-script/CONFIG.gs
+++ b/apps-script/CONFIG.gs
@@ -1,0 +1,17 @@
+/**
+ * Configuration for Calendar sync.
+ * Replace placeholder values with actual IDs before deployment.
+ */
+var CONFIG = {
+  COACHING_CALENDAR_ID: 'primary',
+  FIRESTORE_PROJECT_ID: 'aote-pms',
+  FIRESTORE_DB: '(default)',
+  BACKFILL_DAYS: 365,
+  TIMEZONE: 'Asia/Hong_Kong',
+  SYNC_TOKEN_KEY: 'calendarSyncToken'
+};
+
+function CAL_ID_() {
+  var prop = PropertiesService.getScriptProperties().getProperty('COACHING_CALENDAR_ID');
+  return prop || CONFIG.COACHING_CALENDAR_ID;
+}

--- a/apps-script/Firestore.gs
+++ b/apps-script/Firestore.gs
@@ -1,0 +1,91 @@
+/**
+ * Firestore helper functions for Apps Script (ES5).
+ */
+function getFirestoreToken_() {
+  return ScriptApp.getOAuthToken();
+}
+
+function getFirestoreUrl(path) {
+  var base = 'https://firestore.googleapis.com/v1/projects/' + CONFIG.FIRESTORE_PROJECT_ID + '/databases/' + encodeURIComponent(CONFIG.FIRESTORE_DB) + '/documents';
+  if (path && path.charAt(0) !== '/') path = '/' + path;
+  return base + path;
+}
+
+function writeFirestoreDoc(path, data) {
+  var url = getFirestoreUrl(path);
+  var payload = JSON.stringify({ fields: toFirestoreFields(data) });
+  var resp = UrlFetchApp.fetch(url, {
+    method: 'post',
+    headers: {
+      Authorization: 'Bearer ' + getFirestoreToken_(),
+      'Content-Type': 'application/json',
+      'X-HTTP-Method-Override': 'PATCH'
+    },
+    payload: payload,
+    muteHttpExceptions: true
+  });
+  if (resp.getResponseCode() >= 400) {
+    Logger.log('Firestore write error %s: %s', path, resp.getContentText().substring(0, 1000));
+  }
+  return resp;
+}
+
+function getDocument_(path) {
+  var url = getFirestoreUrl(path);
+  var resp = UrlFetchApp.fetch(url, {
+    headers: { Authorization: 'Bearer ' + getFirestoreToken_() },
+    muteHttpExceptions: true
+  });
+  if (resp.getResponseCode() === 404) {
+    return null;
+  }
+  return JSON.parse(resp.getContentText());
+}
+
+function runQuery_(structuredQuery, parent) {
+  var path = parent ? parent + ':runQuery' : ':runQuery';
+  var url = getFirestoreUrl(path);
+  var resp = UrlFetchApp.fetch(url, {
+    method: 'post',
+    headers: {
+      Authorization: 'Bearer ' + getFirestoreToken_(),
+      'Content-Type': 'application/json'
+    },
+    payload: JSON.stringify({ structuredQuery: structuredQuery }),
+    muteHttpExceptions: true
+  });
+  return JSON.parse(resp.getContentText());
+}
+
+function toFirestoreFields(obj) {
+  var fields = {};
+  for (var key in obj) {
+    var val = obj[key];
+    if (val === null || val === undefined) continue;
+    if (Object.prototype.toString.call(val) === '[object Date]') {
+      fields[key] = { timestampValue: val.toISOString() };
+    } else if (typeof val === 'string') {
+      fields[key] = { stringValue: val };
+    } else if (typeof val === 'number') {
+      if (Math.floor(val) === val) {
+        fields[key] = { integerValue: String(val) };
+      } else {
+        fields[key] = { doubleValue: val };
+      }
+    } else if (typeof val === 'boolean') {
+      fields[key] = { booleanValue: val };
+    } else if (Object.prototype.toString.call(val) === '[object Array]') {
+      var arr = [];
+      for (var i = 0; i < val.length; i++) {
+        var v = val[i];
+        if (typeof v === 'string') {
+          arr.push({ stringValue: v });
+        }
+      }
+      fields[key] = { arrayValue: { values: arr } };
+    } else if (typeof val === 'object') {
+      fields[key] = { mapValue: { fields: toFirestoreFields(val) } };
+    }
+  }
+  return fields;
+}

--- a/apps-script/Firestore.gs
+++ b/apps-script/Firestore.gs
@@ -42,18 +42,28 @@ function getDocument_(path) {
   return JSON.parse(resp.getContentText());
 }
 
-function runQuery_(structuredQuery, parent) {
-  var path = parent ? parent + ':runQuery' : ':runQuery';
-  var url = getFirestoreUrl(path);
+function runQuery_(structuredQuery, parentPath) {
+  var url = 'https://firestore.googleapis.com/v1/projects/' +
+    CONFIG.FIRESTORE_PROJECT_ID + '/databases/' +
+    encodeURIComponent(CONFIG.FIRESTORE_DB) + '/documents:runQuery';
+  var body = { structuredQuery: structuredQuery };
+  if (parentPath) {
+    if (parentPath.charAt(0) === '/') parentPath = parentPath.substring(1);
+    body.parent = 'projects/' + CONFIG.FIRESTORE_PROJECT_ID +
+      '/databases/' + CONFIG.FIRESTORE_DB + '/documents/' + parentPath;
+  }
   var resp = UrlFetchApp.fetch(url, {
     method: 'post',
     headers: {
       Authorization: 'Bearer ' + getFirestoreToken_(),
       'Content-Type': 'application/json'
     },
-    payload: JSON.stringify({ structuredQuery: structuredQuery }),
+    payload: JSON.stringify(body),
     muteHttpExceptions: true
   });
+  if (resp.getResponseCode() >= 400) {
+    Logger.log('Firestore query error: %s', resp.getContentText().substring(0, 1000));
+  }
   return JSON.parse(resp.getContentText());
 }
 

--- a/apps-script/ScanEndpoint.gs
+++ b/apps-script/ScanEndpoint.gs
@@ -1,0 +1,58 @@
+/**
+ * Web endpoint for triggering calendar scans.
+ */
+function doPost(e) {
+  var body = {};
+  try {
+    if (e && e.postData && e.postData.contents) {
+      body = JSON.parse(e.postData.contents);
+    }
+  } catch (err) {}
+  var action = body.action || 'scanAll';
+  if (action === 'scanOne') {
+    var account = body.account;
+    var daysBack = body.daysBack;
+    var daysForward = body.daysForward;
+    var result = scanAccountWindow_(account, daysBack, daysForward);
+    return ContentService.createTextOutput(JSON.stringify(result)).setMimeType(ContentService.MimeType.JSON);
+  } else {
+    if (body.forceFull) clearSyncToken();
+    var res = syncCalendarChanges();
+    return ContentService.createTextOutput(JSON.stringify(res)).setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+function doGet(e) {
+  return doPost(e);
+}
+
+function scanAccountWindow_(account, daysBack, daysForward) {
+  abbrCache = {};
+  var now = new Date();
+  var back = daysBack || 365;
+  var forward = daysForward || 90;
+  var params = {
+    timeMin: new Date(now.getTime() - back * 24 * 60 * 60 * 1000).toISOString(),
+    timeMax: new Date(now.getTime() + forward * 24 * 60 * 60 * 1000).toISOString(),
+    singleEvents: true,
+    orderBy: 'startTime'
+  };
+  var processed = {};
+  var pageToken;
+  do {
+    if (pageToken) params.pageToken = pageToken;
+    var resp = calendarListWithRetry_(CAL_ID_(), params);
+    var items = resp.items || [];
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      var parsed = parseAccountAndType_(item.summary);
+      if (!parsed.account || parsed.account !== account) continue;
+      var eventId = extractEventId(item);
+      if (!eventId || processed[eventId]) continue;
+      processed[eventId] = true;
+      handleCalendarItem_(eventId, item);
+    }
+    pageToken = resp.nextPageToken;
+  } while (pageToken);
+  return { processed: Object.keys(processed).length };
+}

--- a/apps-script/SessionSync.gs
+++ b/apps-script/SessionSync.gs
@@ -170,7 +170,7 @@ function logEventHistory_(encodedEventId, entry) {
     from: [{ collectionId: 'AppointmentHistory' }],
     orderBy: [{ field: { fieldPath: 'changeTimestamp' }, direction: 'DESCENDING' }],
     limit: 1
-  }, histPath);
+  }, 'Sessions/' + encodedEventId);
   if (existing && existing.length && existing[0].document) {
     var fields = existing[0].document.fields || {};
     if (fields.type && fields.type.stringValue === entry.type &&

--- a/apps-script/SessionSync.gs
+++ b/apps-script/SessionSync.gs
@@ -1,0 +1,223 @@
+/**
+ * Core sync logic for Calendar events into Firestore.
+ */
+var DAY_MS = 24 * 60 * 60 * 1000;
+
+function syncCalendarChanges() {
+  abbrCache = {};
+  var props = PropertiesService.getScriptProperties();
+  var processed = {};
+  var now = new Date();
+  var token = props.getProperty(CONFIG.SYNC_TOKEN_KEY);
+  var lastResponse = null;
+
+  while (true) {
+    var params = { singleEvents: true };
+    if (token) {
+      params.syncToken = token;
+    } else {
+      params.timeMin = new Date(now.getTime() - CONFIG.BACKFILL_DAYS * DAY_MS).toISOString();
+      params.timeMax = now.toISOString();
+      params.orderBy = 'updated';
+    }
+
+    var pageToken = null;
+    try {
+      do {
+        if (pageToken) params.pageToken = pageToken;
+        var response = calendarListWithRetry_(CAL_ID_(), params);
+        lastResponse = response;
+        var items = response.items || [];
+        for (var i = 0; i < items.length; i++) {
+          var item = items[i];
+          var eventId = extractEventId(item);
+          if (!eventId || processed[eventId]) continue;
+          processed[eventId] = true;
+          handleCalendarItem_(eventId, item);
+        }
+        pageToken = response.nextPageToken;
+      } while (pageToken);
+      break;
+    } catch (err) {
+      var msg = err && err.message ? err.message : '';
+      if (err && (err.code === 410 || err.code === 400 || msg.toLowerCase().indexOf('sync token') !== -1)) {
+        clearSyncToken();
+        token = null;
+        pageToken = null;
+        continue;
+      } else {
+        Logger.log('Calendar sync error: ' + msg);
+        break;
+      }
+    }
+  }
+
+  if (lastResponse && lastResponse.nextSyncToken) {
+    props.setProperty(CONFIG.SYNC_TOKEN_KEY, lastResponse.nextSyncToken);
+  }
+  return { processed: Object.keys(processed).length };
+}
+
+function handleCalendarItem_(eventId, item) {
+  if (!item || !item.summary) {
+    Logger.log('Skipping event %s with no title', eventId);
+    return;
+  }
+  item = createDummyEvent(item);
+  var parsed = parseAccountAndType_(item.summary);
+  var account = parsed.account;
+  if (!account) {
+    Logger.log('Skipping event %s missing account', eventId);
+    return;
+  }
+  var sessionType = parsed.sessionType;
+  if (item.status === 'cancelled') sessionType = 'cancelled';
+  var start = new Date(item.start.dateTime || item.start.date);
+  var end = new Date(item.end.dateTime || item.end.date);
+  var abbr = resolveAbbrByAccount_(account);
+
+  var encodedId = encodeURIComponent(eventId);
+  var docPath = 'Sessions/' + encodedId;
+  var existing = getDocument_(docPath);
+  var prevType = null;
+  var prevStart = null;
+  var prevEnd = null;
+  if (existing && existing.fields) {
+    if (existing.fields.sessionType && existing.fields.sessionType.stringValue)
+      prevType = existing.fields.sessionType.stringValue;
+    if (existing.fields.origStartTimestamp && existing.fields.origStartTimestamp.timestampValue)
+      prevStart = new Date(existing.fields.origStartTimestamp.timestampValue);
+    if (existing.fields.origEndTimestamp && existing.fields.origEndTimestamp.timestampValue)
+      prevEnd = new Date(existing.fields.origEndTimestamp.timestampValue);
+  }
+
+  var data = {
+    sessionName: account,
+    account: account,
+    abbr: abbr,
+    sessionType: sessionType,
+    origStartTimestamp: start,
+    origEndTimestamp: end,
+    updatedAt: new Date(),
+    source: 'calendar'
+  };
+  if (!existing) data.createdAt = new Date();
+  upsertSessionDoc_(docPath, data);
+
+  var historyType = null;
+  var historySessionType = sessionType;
+  var origStart = start;
+  var origEnd = end;
+  var newStart = null;
+  var newEnd = null;
+
+  if (item.status === 'cancelled') {
+    if (prevType !== 'cancelled') {
+      historyType = 'Deleted';
+      historySessionType = prevType || sessionType;
+      origStart = prevStart || start;
+      origEnd = prevEnd || end;
+    }
+  } else if (!existing) {
+    historyType = 'Created';
+  } else {
+    var changed = false;
+    if (prevType !== sessionType) changed = true;
+    if (!prevStart || prevStart.getTime() !== start.getTime()) changed = true;
+    if (!prevEnd || prevEnd.getTime() !== end.getTime()) changed = true;
+    if (changed) {
+      historyType = 'Changed';
+      origStart = prevStart || start;
+      origEnd = prevEnd || end;
+      newStart = start;
+      newEnd = end;
+    }
+  }
+
+  if (historyType) {
+    logEventHistory_(encodedId, {
+      type: historyType,
+      client: account,
+      sessionType: historySessionType,
+      origStartTimestamp: origStart,
+      origEndTimestamp: origEnd,
+      newStartTimestamp: newStart,
+      newEndTimestamp: newEnd
+    });
+  }
+}
+
+function calendarListWithRetry_(calendarId, params) {
+  var attempts = 0;
+  while (attempts < 5) {
+    try {
+      return Calendar.Events.list(calendarId, params);
+    } catch (err) {
+      attempts++;
+      if (attempts >= 5) throw err;
+      Utilities.sleep(8000);
+    }
+  }
+}
+
+function upsertSessionDoc_(path, data) {
+  writeFirestoreDoc(path, data);
+}
+
+function logEventHistory_(encodedEventId, entry) {
+  var histPath = 'Sessions/' + encodedEventId + '/AppointmentHistory';
+  var existing = runQuery_({
+    from: [{ collectionId: 'AppointmentHistory' }],
+    orderBy: [{ field: { fieldPath: 'changeTimestamp' }, direction: 'DESCENDING' }],
+    limit: 1
+  }, histPath);
+  if (existing && existing.length && existing[0].document) {
+    var fields = existing[0].document.fields || {};
+    if (fields.type && fields.type.stringValue === entry.type &&
+        sameTs_(fields.origStartTimestamp, entry.origStartTimestamp) &&
+        sameTs_(fields.origEndTimestamp, entry.origEndTimestamp) &&
+        sameTs_(fields.newStartTimestamp, entry.newStartTimestamp) &&
+        sameTs_(fields.newEndTimestamp, entry.newEndTimestamp)) {
+      return;
+    }
+  }
+  var now = new Date();
+  var times = formatTime(now);
+  entry.dateStamp = times.dateStamp;
+  entry.timeStamp = times.timeStamp;
+  entry.timestamp = now;
+  entry.changeTimestamp = now;
+  var historyId = Utilities.getUuid();
+  writeFirestoreDoc(histPath + '/' + historyId, entry);
+}
+
+function sameTs_(field, date) {
+  if (field && field.timestampValue) {
+    var cmp = date ? date.toISOString() : null;
+    return field.timestampValue === cmp;
+  }
+  return !date;
+}
+
+function setupHourlySyncTrigger() {
+  ScriptApp.newTrigger('syncCalendarChanges').timeBased().everyHours(1).create();
+}
+
+function cleanupSyncTriggers() {
+  var triggers = ScriptApp.getProjectTriggers();
+  for (var i = 0; i < triggers.length; i++) {
+    if (triggers[i].getHandlerFunction() === 'syncCalendarChanges') {
+      ScriptApp.deleteTrigger(triggers[i]);
+    }
+  }
+}
+
+function auditAllEvents() {
+  clearSyncToken();
+  return syncCalendarChanges();
+}
+
+function clearSyncToken() {
+  PropertiesService.getScriptProperties().deleteProperty(CONFIG.SYNC_TOKEN_KEY);
+}
+

--- a/apps-script/Utils.gs
+++ b/apps-script/Utils.gs
@@ -1,0 +1,103 @@
+/**
+ * Utility helpers for Calendar syncing.
+ */
+var abbrCache = {};
+
+function formatTime(date) {
+  return {
+    dateStamp: Utilities.formatDate(date, CONFIG.TIMEZONE, 'yyyy-MM-dd'),
+    timeStamp: Utilities.formatDate(date, CONFIG.TIMEZONE, 'HH:mm:ss'),
+    timestamp: date.toISOString()
+  };
+}
+
+function extractEventId(item) {
+  if (item && item.id) return item.id.split('@')[0];
+  if (item && item.iCalUID) return item.iCalUID.split('@')[0];
+  return null;
+}
+
+function createDummyEvent(item) {
+  if (item && item.start && item.start.date && !item.start.dateTime) {
+    var start = new Date(item.start.date + 'T00:00:00');
+    var end = item.end && item.end.date ? new Date(item.end.date + 'T00:00:00') : new Date(start.getTime() + 24 * 60 * 60 * 1000);
+    item.start.dateTime = start.toISOString();
+    item.end.dateTime = end.toISOString();
+  }
+  return item;
+}
+
+function parseAccountAndType_(title) {
+  if (!title) return { account: null, sessionType: 'physical' };
+  var t = title.replace(/^Vocal Sessions Booking System[:\s-]*/i, '');
+  var virtual = false;
+  t = t.replace(/\((FaceTime|Zoom|Online)\)/gi, function () {
+    virtual = true;
+    return '';
+  });
+  t = t.replace(/\s(?:-|\|)\s.*$/, '');
+  t = t.replace(/\s+/g, ' ').trim();
+  return { account: t || null, sessionType: virtual ? 'virtual' : 'physical' };
+}
+
+function resolveAbbrByAccount_(account) {
+  if (!account) return null;
+  var norm = account.toLowerCase().trim();
+  if (abbrCache[norm]) return abbrCache[norm];
+  var query = {
+    from: [{ collectionId: 'Students' }],
+    where: {
+      fieldFilter: {
+        field: { fieldPath: 'account' },
+        op: 'EQUAL',
+        value: { stringValue: account.trim() }
+      }
+    },
+    limit: 1
+  };
+  var abbr = extractAbbrFromDocs_(runQuery_(query), norm);
+  if (!abbr) {
+    var aliasQuery = {
+      from: [{ collectionId: 'Students' }],
+      where: {
+        fieldFilter: {
+          field: { fieldPath: 'aliases' },
+          op: 'ARRAY_CONTAINS',
+          value: { stringValue: account.trim() }
+        }
+      },
+      limit: 5
+    };
+    abbr = extractAbbrFromDocs_(runQuery_(aliasQuery), norm);
+  }
+  if (!abbr) {
+    abbr = extractAbbrFromDocs_(runQuery_({ from: [{ collectionId: 'Students' }], limit: 1000 }), norm);
+  }
+  abbrCache[norm] = abbr;
+  return abbr;
+}
+
+function extractAbbrFromDocs_(resp, norm) {
+  if (!resp || !resp.length) return null;
+  for (var i = 0; i < resp.length; i++) {
+    if (!resp[i].document) continue;
+    var doc = resp[i].document;
+    var fields = doc.fields || {};
+    var acc = fields.account && fields.account.stringValue ? fields.account.stringValue.toLowerCase().trim() : '';
+    if (acc === norm) {
+      var parts = doc.name.split('/');
+      return parts[parts.length - 1];
+    }
+    if (fields.aliases && fields.aliases.arrayValue && fields.aliases.arrayValue.values) {
+      var arr = fields.aliases.arrayValue.values;
+      for (var j = 0; j < arr.length; j++) {
+        var a = arr[j].stringValue ? arr[j].stringValue.toLowerCase().trim() : '';
+        if (a === norm) {
+          var p = doc.name.split('/');
+          return p[p.length - 1];
+        }
+      }
+    }
+  }
+  return null;
+}

--- a/components/StudentDialog/OverviewTab.tsx
+++ b/components/StudentDialog/OverviewTab.tsx
@@ -4,6 +4,8 @@ import React, { useEffect, useState, useCallback, useRef } from 'react'
 import { Tabs, Tab, Box, CircularProgress, Typography } from '@mui/material'
 import FloatingWindow from './FloatingWindow'
 import { titleFor, MainTab, BillingSubTab } from './title'
+import { useBilling } from '../../lib/billing/useBilling'
+import { getCountsFromBilling } from '../../lib/billing/counts'
 
 // OverviewTab acts purely as a presenter. PersonalTab, SessionsTab and
 // BillingTab each fetch and compute their own data then "stream" summary
@@ -80,6 +82,9 @@ export default function OverviewTab({
     [tab, subTab, account],
   )
   const [actions, setActions] = useState<React.ReactNode | null>(null)
+  const { data: bill } = useBilling(abbr, account)
+  const counts = getCountsFromBilling(bill)
+  const [hoverCount, setHoverCount] = useState(false)
 
   // personal summary streamed from PersonalTab
   const [personal, setPersonal] = useState<any>({})
@@ -281,23 +286,20 @@ export default function OverviewTab({
                   sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
                 >
                   Total Sessions:{' '}
-                  {overviewLoading && <CircularProgress size={14} />}
+                  {!bill && <CircularProgress size={14} className="slow-blink" />}
                 </Typography>
-                {overviewLoading ? (
-                  <Typography
-                    variant="h6"
-                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
-                  >
-                    Loading…
-                  </Typography>
-                ) : (
-                  <Typography
-                    variant="h6"
-                    sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
-                  >
-                    {overview.total ?? '–'}
-                  </Typography>
-                )}
+                <Typography
+                  variant="h6"
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                  onMouseEnter={() => setHoverCount(true)}
+                  onMouseLeave={() => setHoverCount(false)}
+                >
+                  {!bill
+                    ? '–'
+                    : hoverCount
+                    ? `✅ ${counts.total - counts.cancelled}`
+                    : `${counts.total} (❌ ${counts.cancelled})`}
+                </Typography>
 
                 <Typography
                   variant="subtitle2"

--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -307,6 +307,7 @@ export default function PaymentDetail({
         <Typography
           variant="h6"
           sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+          className={remaining > 0 ? 'yellow-blink' : undefined}
         >
           {formatCurrency(remaining)}{' '}
           {totalSelected > 0 && (

--- a/components/StudentDialog/PaymentHistory.tsx
+++ b/components/StudentDialog/PaymentHistory.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useMemo } from 'react'
 import {
   Box,
   Table,
@@ -12,6 +12,9 @@ import {
   IconButton,
   Tooltip,
 } from '@mui/material'
+import { useSession } from 'next-auth/react'
+import { useBilling } from '../../lib/billing/useBilling'
+import { useColumnWidths } from '../../lib/useColumnWidths'
 import { collection, orderBy, query, onSnapshot } from 'firebase/firestore'
 import { db } from '../../lib/firebase'
 import PaymentDetail from './PaymentDetail'
@@ -60,6 +63,23 @@ export default function PaymentHistory({
   const [sortField, setSortField] = useState<'amount' | 'paymentMade'>('paymentMade')
   const [sortAsc, setSortAsc] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
+  const { data: session } = useSession()
+  const { data: bill } = useBilling(abbr, account)
+  const ordinalMap = useMemo(() => {
+    const map: any = {}
+    if (bill) bill.rows.forEach((r: any, i: number) => (map[r.id] = i + 1))
+    return map
+  }, [bill])
+  const columns = [
+    { key: 'paymentMade', label: 'Payment Made On', width: 160 },
+    { key: 'session', label: 'For session', width: 120 },
+    { key: 'amount', label: 'Amount Received', width: 160 },
+  ]
+  const { widths, startResize } = useColumnWidths(
+    'payments',
+    columns,
+    (session && (session.user as any)?.email) || 'anon',
+  )
 
   useEffect(() => {
     if (active) onTitleChange?.(titleFor('billing', 'payment-history', account))
@@ -130,10 +150,18 @@ export default function PaymentHistory({
               </IconButton>
             </Tooltip>
           </Box>
-          <Table size="small" sx={{ cursor: 'pointer' }}>
+          <Table size="small" sx={{ cursor: 'pointer', tableLayout: 'fixed', width: 'max-content' }}>
             <TableHead>
               <TableRow>
-                <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Cantata One',
+                    fontWeight: 'bold',
+                    width: widths.paymentMade,
+                    minWidth: widths.paymentMade,
+                    position: 'relative',
+                  }}
+                >
                   <TableSortLabel
                     active={sortField === 'paymentMade'}
                     direction={sortField === 'paymentMade' && sortAsc ? 'asc' : 'desc'}
@@ -147,8 +175,35 @@ export default function PaymentHistory({
                   >
                     Payment Made On
                   </TableSortLabel>
+                  <Box
+                    onMouseDown={(e) => startResize('paymentMade', e)}
+                    sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+                  />
                 </TableCell>
-                <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Cantata One',
+                    fontWeight: 'bold',
+                    width: widths.session,
+                    minWidth: widths.session,
+                    position: 'relative',
+                  }}
+                >
+                  For session
+                  <Box
+                    onMouseDown={(e) => startResize('session', e)}
+                    sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+                  />
+                </TableCell>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Cantata One',
+                    fontWeight: 'bold',
+                    width: widths.amount,
+                    minWidth: widths.amount,
+                    position: 'relative',
+                  }}
+                >
                   <TableSortLabel
                     active={sortField === 'amount'}
                     direction={sortField === 'amount' && sortAsc ? 'asc' : 'desc'}
@@ -162,36 +217,84 @@ export default function PaymentHistory({
                   >
                     Amount Received
                   </TableSortLabel>
+                  <Box
+                    onMouseDown={(e) => startResize('amount', e)}
+                    sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+                  />
                 </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedPayments.map((p) => (
-                <TableRow
-                  key={p.id}
-                  hover
-                  onClick={() => setDetail(p)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      setDetail(p)
-                    }
-                  }}
-                  sx={{ cursor: 'pointer', py: 1 }}
-                >
-                  <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                    {formatDate(p.paymentMade)}
-                  </TableCell>
-                  <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
-                    {formatCurrency(Number(p.amount) || 0)}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {sortedPayments.map((p) => {
+                const nums: string[] = []
+                if (p.assignedSessions && p.assignedSessions.length > 0) {
+                  p.assignedSessions.forEach((id: string) => {
+                    const n = ordinalMap[id]
+                    if (n) nums.push(String(n))
+                  })
+                }
+                const sessDisplay = nums.length > 0 ? nums.join(', ') : '–'
+                const remaining = Number(p.remainingAmount) || 0
+                return (
+                  <TableRow
+                    key={p.id}
+                    hover
+                    onClick={() => setDetail(p)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        setDetail(p)
+                      }
+                    }}
+                    sx={{ cursor: 'pointer', py: 1 }}
+                  >
+                    <TableCell
+                      sx={{
+                        fontFamily: 'Newsreader',
+                        fontWeight: 500,
+                        width: widths.paymentMade,
+                        minWidth: widths.paymentMade,
+                      }}
+                    >
+                      {formatDate(p.paymentMade)}
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontFamily: 'Newsreader',
+                        fontWeight: 500,
+                        width: widths.session,
+                        minWidth: widths.session,
+                      }}
+                    >
+                      <Tooltip
+                        title={
+                          p.assignedSessions && p.assignedSessions.length
+                            ? p.assignedSessions.join(', ')
+                            : ''
+                        }
+                      >
+                        <span>{sessDisplay}</span>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell
+                      className={remaining > 0 ? 'yellow-blink' : undefined}
+                      sx={{
+                        fontFamily: 'Newsreader',
+                        fontWeight: 500,
+                        width: widths.amount,
+                        minWidth: widths.amount,
+                      }}
+                    >
+                      {formatCurrency(Number(p.amount) || 0)}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
               {sortedPayments.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={2} sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  <TableCell colSpan={3} sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
                     No payments recorded.
                   </TableCell>
                 </TableRow>

--- a/components/StudentDialog/RetainersTab.tsx
+++ b/components/StudentDialog/RetainersTab.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useColumnWidths } from '../../lib/useColumnWidths'
 import {
   Box,
   Typography,
@@ -53,6 +55,19 @@ export default function RetainersTab({
     retainer?: RetRow
     nextStart?: Date
   }>({ open: false })
+  const { data: session } = useSession()
+  const columns = [
+    { key: 'retainer', label: 'Retainer', width: 120 },
+    { key: 'period', label: 'Coverage Period', width: 200 },
+    { key: 'rate', label: 'Rate', width: 120 },
+    { key: 'status', label: 'Status', width: 120 },
+    { key: 'actions', label: 'Actions', width: 100 },
+  ]
+  const { widths, startResize } = useColumnWidths(
+    'retainers',
+    columns,
+    (session && (session.user as any)?.email) || 'anon',
+  )
 
   const load = async () => {
     try {
@@ -87,7 +102,7 @@ export default function RetainersTab({
     .sort((a, b) => a.s.getTime() - b.s.getTime())[0]?.row
 
   return (
-    <Box sx={{ p: 1, textAlign: 'left', height: '100%' }}>
+    <Box sx={{ p: 1, textAlign: 'left', height: '100%', overflow: 'auto' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
         <Typography
           variant="subtitle1"
@@ -113,10 +128,18 @@ export default function RetainersTab({
           </Tooltip>
         </Box>
       </Box>
-      <Table size="small">
+      <Table size="small" sx={{ tableLayout: 'fixed', width: 'max-content' }}>
         <TableHead>
           <TableRow>
-            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+            <TableCell
+              sx={{
+                fontFamily: 'Cantata One',
+                fontWeight: 'bold',
+                width: widths.retainer,
+                minWidth: widths.retainer,
+                position: 'relative',
+              }}
+            >
               <TableSortLabel
                 active
                 direction={sortAsc ? 'asc' : 'desc'}
@@ -124,18 +147,70 @@ export default function RetainersTab({
               >
                 Retainer
               </TableSortLabel>
+              <Box
+                onMouseDown={(e) => startResize('retainer', e)}
+                sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+              />
             </TableCell>
-            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+            <TableCell
+              sx={{
+                fontFamily: 'Cantata One',
+                fontWeight: 'bold',
+                width: widths.period,
+                minWidth: widths.period,
+                position: 'relative',
+              }}
+            >
               Coverage Period
+              <Box
+                onMouseDown={(e) => startResize('period', e)}
+                sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+              />
             </TableCell>
-            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+            <TableCell
+              sx={{
+                fontFamily: 'Cantata One',
+                fontWeight: 'bold',
+                width: widths.rate,
+                minWidth: widths.rate,
+                position: 'relative',
+              }}
+            >
               Rate
+              <Box
+                onMouseDown={(e) => startResize('rate', e)}
+                sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+              />
             </TableCell>
-            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+            <TableCell
+              sx={{
+                fontFamily: 'Cantata One',
+                fontWeight: 'bold',
+                width: widths.status,
+                minWidth: widths.status,
+                position: 'relative',
+              }}
+            >
               Status
+              <Box
+                onMouseDown={(e) => startResize('status', e)}
+                sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+              />
             </TableCell>
-            <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>
+            <TableCell
+              sx={{
+                fontFamily: 'Cantata One',
+                fontWeight: 'bold',
+                width: widths.actions,
+                minWidth: widths.actions,
+                position: 'relative',
+              }}
+            >
               Actions
+              <Box
+                onMouseDown={(e) => startResize('actions', e)}
+                sx={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 4, cursor: 'col-resize' }}
+              />
             </TableCell>
           </TableRow>
         </TableHead>
@@ -163,13 +238,34 @@ export default function RetainersTab({
             })
             return (
               <TableRow key={r.id} hover selected={active}>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Newsreader',
+                    fontWeight: 500,
+                    width: widths.retainer,
+                    minWidth: widths.retainer,
+                  }}
+                >
                   {monthLabel}
                 </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Newsreader',
+                    fontWeight: 500,
+                    width: widths.period,
+                    minWidth: widths.period,
+                  }}
+                >
                   {`${formatDate(r.retainerStarts)} – ${formatDate(r.retainerEnds)}`}
                 </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Newsreader',
+                    fontWeight: 500,
+                    width: widths.rate,
+                    minWidth: widths.rate,
+                  }}
+                >
                   {new Intl.NumberFormat(undefined, {
                     style: 'currency',
                     currency: 'HKD',
@@ -181,13 +277,22 @@ export default function RetainersTab({
                     fontFamily: 'Newsreader',
                     fontWeight: 500,
                     color: colorMap[status.color],
+                    width: widths.status,
+                    minWidth: widths.status,
                   }}
                 >
                   <Tooltip title={status.label}>
                     <span>{status.label}</span>
                   </Tooltip>
                 </TableCell>
-                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                <TableCell
+                  sx={{
+                    fontFamily: 'Newsreader',
+                    fontWeight: 500,
+                    width: widths.actions,
+                    minWidth: widths.actions,
+                  }}
+                >
                   <Button
                     size="small"
                     onClick={() => setModal({ open: true, retainer: r })}

--- a/lib/billing/counts.ts
+++ b/lib/billing/counts.ts
@@ -1,0 +1,7 @@
+import { BillingResult } from './compute'
+
+export function getCountsFromBilling(bill?: BillingResult | null) {
+  if (!bill) return { total: 0, cancelled: 0 }
+  const cancelled = bill.rows.filter(function (r) { return r.flags.cancelled }).length
+  return { total: bill.rows.length, cancelled }
+}

--- a/lib/useColumnWidths.ts
+++ b/lib/useColumnWidths.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react'
+
+interface Col { key: string; width: number }
+
+export function useColumnWidths(tableId: string, cols: Col[], userId: string) {
+  const storageKey = 'tableWidth:' + tableId + ':' + userId
+  const initial: any = {}
+  cols.forEach(function (c) {
+    initial[c.key] = c.width
+  })
+  const [widths, setWidths] = useState(function () {
+    if (typeof window === 'undefined') return initial
+    try {
+      const stored = window.localStorage.getItem(storageKey)
+      if (stored) return JSON.parse(stored)
+    } catch (e) {
+      // ignore
+    }
+    return initial
+  })
+  useEffect(function () {
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(widths))
+    } catch (e) {
+      // ignore
+    }
+  }, [widths, storageKey])
+  function startResize(key: string, e: React.MouseEvent) {
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = widths[key] || initial[key] || 100
+    function onMove(ev: MouseEvent) {
+      const delta = ev.clientX - startX
+      const w = Math.max(60, startW + delta)
+      setWidths(function (prev: any) {
+        const next = { ...prev, [key]: w }
+        return next
+      })
+    }
+    function onUp() {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
+  return { widths, startResize }
+}

--- a/pages/api/calendar-scan.ts
+++ b/pages/api/calendar-scan.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { getAuthOptions } from './auth/[...nextauth]';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const authOptions = await getAuthOptions();
+  const session = await getServerSession(req, res, authOptions);
+  const email = (session as any)?.user?.email as string | undefined;
+  if (!email) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const allowedDomains = (process.env.ADMIN_EMAIL_DOMAINS || 'establishrecords.com')
+    .split(',')
+    .map((d) => d.trim())
+    .filter(Boolean);
+  const allowedEmails = (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map((e) => e.trim())
+    .filter(Boolean);
+  const domain = email.split('@')[1];
+  const authorized = allowedEmails.includes(email) || allowedDomains.includes(domain || '');
+  if (!authorized) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  try {
+    const url = process.env.CALENDAR_SCAN_URL;
+    if (!url) {
+      return res.status(500).json({ error: 'CALENDAR_SCAN_URL not configured' });
+    }
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body && Object.keys(req.body).length ? req.body : { action: 'scanAll' }),
+    });
+    const data = await response.json();
+    return res.status(response.ok ? 200 : 500).json(data);
+  } catch (err: any) {
+    console.error('[api/calendar-scan] error', err);
+    return res.status(500).json({ error: err.message || 'Internal server error' });
+  }
+}

--- a/styles/studentDialog.css
+++ b/styles/studentDialog.css
@@ -17,3 +17,30 @@
     Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-weight: 700;
 }
+
+@keyframes slowBlink {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+.slow-blink {
+  animation: slowBlink 2s ease-in-out infinite;
+}
+
+@keyframes yellowBlink {
+  0%, 100% {
+    background-color: inherit;
+  }
+  50% {
+    background-color: rgba(255, 255, 0, 0.5);
+  }
+}
+
+.yellow-blink {
+  animation: yellowBlink 2s ease-in-out infinite;
+  outline: 0;
+}


### PR DESCRIPTION
## Summary
- switch Apps Script timezone to Asia/Hong_Kong and make calendar ID overrideable via script properties
- strengthen calendar sync utilities with robust title parsing, case-insensitive student lookup, and duplicate-history prevention
- protect calendar scan endpoint behind an admin-only guard and expose one-off account scanning from the coaching sessions page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d9a9cbc1c83239d8b5b8dd607ba44