### PR TITLE
fix: portal dialogs and restore session totals

### DIFF
--- a/components/StudentDialog/PaymentDetail.tsx
+++ b/components/StudentDialog/PaymentDetail.tsx
@@ -69,28 +69,24 @@ export default function PaymentDetail({
   const [retainers, setRetainers] = useState<any[]>([])
 
   const assignedSet = new Set(assignedSessionIds)
-  const sessionRows = bill
-    ? bill.rows
-        .filter(
-          (r) =>
-            !r.flags.cancelled &&
-            !r.flags.voucherUsed &&
-            !r.flags.inRetainer,
-        )
-        .map((r) => ({
-          id: r.id,
-          startMs: r.startMs,
-          date: r.date,
-          time: r.time,
-          rate: r.amountDue,
-          rateDisplay: r.displayRate,
-          assignedPaymentId: r.assignedPaymentId,
-        }))
-        .sort((a, b) => a.startMs - b.startMs)
+  const allRows = bill
+    ? bill.rows.map((r: any, i: number) => ({ ...r, ordinal: i + 1 }))
     : []
-  sessionRows.forEach((r: any, i: number) => {
-    r.ordinal = i + 1
-  })
+  const sessionRows = allRows
+    .filter(
+      (r) => !r.flags.cancelled && !r.flags.voucherUsed && !r.flags.inRetainer,
+    )
+    .map((r) => ({
+      id: r.id,
+      startMs: r.startMs,
+      date: r.date,
+      time: r.time,
+      rate: r.amountDue,
+      rateDisplay: r.displayRate,
+      assignedPaymentId: r.assignedPaymentId,
+      ordinal: r.ordinal,
+    }))
+    .sort((a, b) => a.startMs - b.startMs)
   const assignedSessions = sessionRows.filter((r) => assignedSet.has(r.id))
   const availableSessions = sessionRows.filter(
     (r) => !assignedSet.has(r.id) && !r.assignedPaymentId,

--- a/components/StudentDialog/SessionsTab.tsx
+++ b/components/StudentDialog/SessionsTab.tsx
@@ -418,6 +418,7 @@ export default function SessionsTab({
               id,
               sessionType,
               billingType,
+              ordinal: 0,
               voucherBalance: 0,
               date,
               time,
@@ -486,8 +487,9 @@ export default function SessionsTab({
           }
         }
 
-        rows.forEach((r) => {
+        rows.forEach((r, i) => {
           delete r.rateSpecified
+          r.ordinal = i + 1
         })
 
         const validDates = rows
@@ -495,11 +497,11 @@ export default function SessionsTab({
           .map((r) => r.startMs)
           .sort((a, b) => a - b)
         const today = new Date()
-        const lastPast = validDates.filter(ms => ms <= today.getTime()).pop()
+        const lastPast = validDates.filter((ms) => ms <= today.getTime()).pop()
         const newSummary = {
           jointDate: validDates.length ? toHKDate(new Date(validDates[0])) : '',
           lastSession: lastPast ? toHKDate(new Date(lastPast)) : '',
-          totalSessions: validDates.length,
+          totalSessions: rows.length,
         }
         console.log('Computed summary:', newSummary)
 
@@ -741,7 +743,7 @@ export default function SessionsTab({
                         backgroundColor: 'background.paper',
                       }}
                     >
-                      {i + 1}
+                      {s.ordinal}
                     </TableCell>
                     {visibleCols.includes('date') && (
                       <TableCell

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -5,6 +5,12 @@ const theme = createTheme({
     MuiPopover: { defaultProps: { container: () => document.body } },
     MuiPopper: { defaultProps: { container: () => document.body } },
     MuiMenu: { defaultProps: { container: () => document.body } },
+    MuiDialog: {
+      defaultProps: {
+        container:
+          typeof window !== 'undefined' ? () => document.body : undefined,
+      },
+    },
   },
 });
 

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -182,10 +182,18 @@ export default function CoachingSessions() {
 
           // Listen to billing summary updates on the student document
           const unsub = onSnapshot(doc(db, PATHS.student(b.abbr)), (snap) => {
-            const bd = (snap.data() as any)?.billingSummary?.balanceDue
+            const data = snap.data() as any
+            const bd = data?.billingSummary?.balanceDue
+            const totalSessions = data?.totalSessions
             setStudents((prev) =>
               prev.map((s) =>
-                s.abbr === b.abbr ? { ...s, balanceDue: bd ?? null } : s,
+                s.abbr === b.abbr
+                  ? {
+                      ...s,
+                      balanceDue: bd ?? null,
+                      total: totalSessions ?? s.total,
+                    }
+                  : s,
               ),
             )
           })


### PR DESCRIPTION
## Summary
- ensure MUI Dialog components render into document body to avoid overlay clipping
- count every session (including cancelled) and keep session ordinals stable across views, updating dashboard totals from stored summaries
- define session row objects with an explicit `ordinal` field to satisfy type checks

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8247acb4832398de585c33c1df13