### PR TITLE
feat: autosize columns and unify balance due

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+CALENDAR_SCAN_URL="https://script.google.com/macros/s/AKfycbzESImrT9yROHCEq0HFM70mGNLd_x-HYT-nJ1E9X_urFxxOPKi3XYqHZW79bGk3tqgFZA/exec"
+SCAN_SECRET="choose-a-long-random-string"

--- a/.github/workflows/task-log-guard.yml
+++ b/.github/workflows/task-log-guard.yml
@@ -1,0 +1,23 @@
+name: Task Log Guard
+
+on:
+  pull_request:
+    paths:
+      - 'docs/Task Log.md'
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check Task Log line count
+        run: |
+          git fetch origin main
+          head_lines=$(wc -l < "docs/Task Log.md")
+          base_lines=$(git show origin/main:"docs/Task Log.md" | wc -l)
+          if [ $head_lines -lt $((base_lines - 10)) ]; then
+            echo "Task Log line count decreased by more than 10 (base $base_lines vs head $head_lines)" >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Task Log
+- `docs/Task Log.md` is append-only.
+- Add new rows at the top of each table.
+- Never remove lines; only append new entries.
+
+Please run `npm run lint` and `npm run build` before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ other history records.
 When values are not available from Firestore the UI must remain responsive and show placeholders instead of failing. Empty strings, `null`, or `undefined` values render as **N/A**, while retrieval errors display as **Error**. Numeric or date values that are unavailable should show a dash (`-`).
  
 
+## Environment Variables
+
+Set the following in `.env.local`:
+
+- `CALENDAR_SCAN_URL` – URL of the Apps Script endpoint.
+- `SCAN_SECRET` – shared secret used for calendar scans.
+
 ## Documentation
 
 - [Task Log — Vol. 1](docs/task-log-vol-1.md)

--- a/apps-script/CONFIG.gs
+++ b/apps-script/CONFIG.gs
@@ -7,6 +7,6 @@ var CONFIG = {
   FIRESTORE_PROJECT_ID: 'REPLACE_WITH_PROJECT_ID',
   FIRESTORE_DB: '(default)',
   BACKFILL_DAYS: 365,
-  TIMEZONE: 'America/New_York',
+  TIMEZONE: 'Asia/Hong_Kong',
   SYNC_TOKEN_KEY: 'calendarSyncToken'
 };

--- a/apps-script/Firestore.gs
+++ b/apps-script/Firestore.gs
@@ -66,7 +66,11 @@ function toFirestoreFields(obj) {
     } else if (typeof val === 'string') {
       fields[key] = { stringValue: val };
     } else if (typeof val === 'number') {
-      fields[key] = { integerValue: String(val) };
+      if (Math.floor(val) === val) {
+        fields[key] = { integerValue: String(val) };
+      } else {
+        fields[key] = { doubleValue: val };
+      }
     } else if (typeof val === 'boolean') {
       fields[key] = { booleanValue: val };
     } else if (Object.prototype.toString.call(val) === '[object Array]') {

--- a/apps-script/ScanEndpoint.gs
+++ b/apps-script/ScanEndpoint.gs
@@ -7,6 +7,17 @@ function doPost(e) {
     if (e && e.postData && e.postData.contents) {
       body = JSON.parse(e.postData.contents);
     }
+    var props = PropertiesService.getScriptProperties();
+    var secret = props.getProperty('SCAN_SECRET');
+    var headerSecret = '';
+    if (e && e.headers) {
+      headerSecret = e.headers['X-Scan-Secret'] || e.headers['x-scan-secret'];
+    }
+    if (!headerSecret || headerSecret !== secret) {
+      return ContentService.createTextOutput(
+        JSON.stringify({ ok: false, message: 'unauthorized' }),
+      ).setMimeType(ContentService.MimeType.JSON);
+    }
     var action = body.action || 'scanAll';
     if (action === 'scanOne') {
       var account = body.account;

--- a/components/StudentDialog/BaseRateHistoryDialog.tsx
+++ b/components/StudentDialog/BaseRateHistoryDialog.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TextField,
+} from '@mui/material'
+import { collection, addDoc, query, orderBy, onSnapshot, Timestamp } from 'firebase/firestore'
+import { db } from '../../lib/firebase'
+import { PATHS, logPath } from '../../lib/paths'
+import { useSession } from 'next-auth/react'
+import { useBillingClient } from '../../lib/billing/useBilling'
+import { writeSummaryFromCache } from '../../lib/liveRefresh'
+
+export default function BaseRateHistoryDialog({
+  abbr,
+  account,
+  open,
+  onClose,
+}: {
+  abbr: string
+  account: string
+  open: boolean
+  onClose: () => void
+}) {
+  const [rows, setRows] = useState<any[]>([])
+  const [rate, setRate] = useState('')
+  const { data: session } = useSession()
+  const qc = useBillingClient()
+  const formatDate = (v: any) => {
+    if (!v) return 'N/A'
+    try {
+      const d = v.toDate ? v.toDate() : new Date(v)
+      return isNaN(d.getTime())
+        ? 'N/A'
+        : d.toLocaleDateString(undefined, {
+            month: 'short',
+            day: '2-digit',
+            year: 'numeric',
+          })
+    } catch {
+      return 'N/A'
+    }
+  }
+
+  useEffect(() => {
+    if (!open) return
+    const path = PATHS.baseRateHistory(abbr)
+    logPath('baseRateHistory', path)
+    const q = query(collection(db, path), orderBy('timestamp', 'desc'))
+    const unsub = onSnapshot(q, (snap) => {
+      setRows(snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })))
+    })
+    return () => unsub()
+  }, [abbr, open])
+
+  const add = async () => {
+    const path = PATHS.baseRateHistory(abbr)
+    await addDoc(collection(db, path), {
+      rate: Number(rate) || 0,
+      timestamp: Timestamp.fromDate(new Date()),
+      editedBy: session?.user?.email || 'unknown',
+    })
+    setRate('')
+    await writeSummaryFromCache(qc, abbr, account)
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ fontFamily: 'Cantata One' }}>Base Rate History</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="New Rate"
+          type="number"
+          value={rate}
+          onChange={(e) => setRate(e.target.value)}
+          fullWidth
+          sx={{ my: 1 }}
+          InputLabelProps={{
+            sx: { fontFamily: 'Newsreader', fontWeight: 200 },
+          }}
+          inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
+        />
+        <Button onClick={add} variant="contained" disabled={!rate} sx={{ mb: 2 }}>
+          Add
+        </Button>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>Rate</TableCell>
+              <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>Timestamp</TableCell>
+              <TableCell sx={{ fontFamily: 'Cantata One', fontWeight: 'bold' }}>Edited By</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((r) => (
+              <TableRow key={r.id}>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  {r.rate}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  {formatDate(r.timestamp)}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}>
+                  {r.editedBy || 'unknown'}
+                </TableCell>
+              </TableRow>
+            ))}
+            {rows.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={3}
+                  sx={{ fontFamily: 'Newsreader', fontWeight: 500 }}
+                >
+                  No history.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/components/StudentDialog/PaymentModal.tsx
+++ b/components/StudentDialog/PaymentModal.tsx
@@ -42,16 +42,7 @@ export default function PaymentModal({
   }
 
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      fullWidth
-      maxWidth="xs"
-      slotProps={{
-        backdrop: { sx: { zIndex: 1600 } },
-        paper: { sx: { zIndex: 1601 } },
-      }}
-    >
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
       <DialogTitle sx={{ fontFamily: 'Cantata One' }}>Add Payment</DialogTitle>
       <DialogContent>
         <TextField
@@ -62,6 +53,10 @@ export default function PaymentModal({
           fullWidth
           autoFocus
           sx={{ mt: 1 }}
+          InputLabelProps={{
+            sx: { fontFamily: 'Newsreader', fontWeight: 200 },
+          }}
+          inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
         />
         <TextField
           label="Payment Made On"
@@ -69,7 +64,11 @@ export default function PaymentModal({
           value={madeOn}
           onChange={(e) => setMadeOn(e.target.value)}
           fullWidth
-          InputLabelProps={{ shrink: true }}
+          InputLabelProps={{
+            shrink: true,
+            sx: { fontFamily: 'Newsreader', fontWeight: 200 },
+          }}
+          inputProps={{ style: { fontFamily: 'Newsreader', fontWeight: 500 } }}
           sx={{ mt: 2 }}
         />
       </DialogContent>

--- a/components/StudentDialog/RetainersTab.tsx
+++ b/components/StudentDialog/RetainersTab.tsx
@@ -18,6 +18,7 @@ import RetainerModal from './RetainerModal'
 import { WriteIcon } from './icons'
 import { useSession } from 'next-auth/react'
 import { useColumnWidths } from '../../lib/useColumnWidths'
+import IconButton from '@mui/material/IconButton'
 
 const formatDate = (v: any) => {
   try {
@@ -63,7 +64,12 @@ export default function RetainersTab({
     { key: 'status', width: 120 },
     { key: 'actions', width: 100 },
   ] as const
-  const { widths, startResize } = useColumnWidths('retainers', columns, userEmail)
+  const { widths, startResize, dblClickResize } = useColumnWidths(
+    'retainers',
+    columns,
+    userEmail,
+  )
+  const tableRef = React.useRef<HTMLTableElement>(null)
 
   const load = async () => {
     try {
@@ -100,16 +106,39 @@ export default function RetainersTab({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', textAlign: 'left' }}>
       <Box sx={{ flexGrow: 1, overflow: 'auto', p: 1, pb: '64px' }}>
-        <Typography
-          variant="subtitle1"
-          sx={{ fontFamily: 'Cantata One', textDecoration: 'underline', mb: 1 }}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+          <Typography
+            variant="subtitle1"
+            sx={{ fontFamily: 'Cantata One', textDecoration: 'underline' }}
+          >
+            Retainers
+          </Typography>
+          <Tooltip title="Add Retainer">
+            <IconButton
+              color="primary"
+              aria-label="Add Retainer"
+              onClick={() =>
+                setModal({
+                  open: true,
+                  nextStart: rows[rows.length - 1]
+                    ? rows[rows.length - 1].retainerEnds.toDate()
+                    : undefined,
+                })
+              }
+            >
+              <WriteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Table
+          ref={tableRef}
+          size="small"
+          sx={{ tableLayout: 'fixed', width: 'max-content' }}
         >
-          Retainers
-        </Typography>
-        <Table size="small" sx={{ tableLayout: 'fixed', width: 'max-content' }}>
         <TableHead>
           <TableRow>
             <TableCell
+              data-col="retainer"
               sx={{
                 fontFamily: 'Cantata One',
                 fontWeight: 'bold',
@@ -129,9 +158,13 @@ export default function RetainersTab({
                 className="col-resizer"
                 aria-label="Resize column Retainer"
                 onMouseDown={(e) => startResize('retainer', e)}
+                onDoubleClick={() =>
+                  dblClickResize('retainer', tableRef.current || undefined)
+                }
               />
             </TableCell>
             <TableCell
+              data-col="period"
               sx={{
                 fontFamily: 'Cantata One',
                 fontWeight: 'bold',
@@ -145,9 +178,13 @@ export default function RetainersTab({
                 className="col-resizer"
                 aria-label="Resize column Coverage Period"
                 onMouseDown={(e) => startResize('period', e)}
+                onDoubleClick={() =>
+                  dblClickResize('period', tableRef.current || undefined)
+                }
               />
             </TableCell>
             <TableCell
+              data-col="rate"
               sx={{
                 fontFamily: 'Cantata One',
                 fontWeight: 'bold',
@@ -161,9 +198,13 @@ export default function RetainersTab({
                 className="col-resizer"
                 aria-label="Resize column Rate"
                 onMouseDown={(e) => startResize('rate', e)}
+                onDoubleClick={() =>
+                  dblClickResize('rate', tableRef.current || undefined)
+                }
               />
             </TableCell>
             <TableCell
+              data-col="status"
               sx={{
                 fontFamily: 'Cantata One',
                 fontWeight: 'bold',
@@ -177,9 +218,13 @@ export default function RetainersTab({
                 className="col-resizer"
                 aria-label="Resize column Status"
                 onMouseDown={(e) => startResize('status', e)}
+                onDoubleClick={() =>
+                  dblClickResize('status', tableRef.current || undefined)
+                }
               />
             </TableCell>
             <TableCell
+              data-col="actions"
               sx={{
                 fontFamily: 'Cantata One',
                 fontWeight: 'bold',
@@ -193,6 +238,9 @@ export default function RetainersTab({
                 className="col-resizer"
                 aria-label="Resize column Actions"
                 onMouseDown={(e) => startResize('actions', e)}
+                onDoubleClick={() =>
+                  dblClickResize('actions', tableRef.current || undefined)
+                }
               />
             </TableCell>
           </TableRow>
@@ -222,6 +270,7 @@ export default function RetainersTab({
             return (
               <TableRow key={r.id} hover selected={active}>
                 <TableCell
+                  data-col="retainer"
                   sx={{
                     fontFamily: 'Newsreader',
                     fontWeight: 500,
@@ -232,6 +281,7 @@ export default function RetainersTab({
                   {monthLabel}
                 </TableCell>
                 <TableCell
+                  data-col="period"
                   sx={{
                     fontFamily: 'Newsreader',
                     fontWeight: 500,
@@ -242,6 +292,7 @@ export default function RetainersTab({
                   {`${formatDate(r.retainerStarts)} – ${formatDate(r.retainerEnds)}`}
                 </TableCell>
                 <TableCell
+                  data-col="rate"
                   sx={{
                     fontFamily: 'Newsreader',
                     fontWeight: 500,
@@ -256,6 +307,7 @@ export default function RetainersTab({
                   }).format(r.retainerRate)}
                 </TableCell>
                 <TableCell
+                  data-col="status"
                   sx={{
                     fontFamily: 'Newsreader',
                     fontWeight: 500,
@@ -269,6 +321,7 @@ export default function RetainersTab({
                   </Tooltip>
                 </TableCell>
                 <TableCell
+                  data-col="actions"
                   sx={{
                     fontFamily: 'Newsreader',
                     fontWeight: 500,
@@ -295,32 +348,13 @@ export default function RetainersTab({
             balanceDue={balanceDue}
             retainer={modal.retainer}
             nextStart={modal.nextStart}
+            open={modal.open}
             onClose={(saved) => {
               setModal({ open: false })
               if (saved) load()
             }}
           />
         )}
-      </Box>
-      <Box
-        className="dialog-footer"
-        sx={{ p: 1, display: 'flex', justifyContent: 'space-between' }}
-      >
-        <span />
-        <Button
-          variant="contained"
-          onClick={() =>
-            setModal({
-              open: true,
-              nextStart: rows[rows.length - 1]
-                ? rows[rows.length - 1].retainerEnds.toDate()
-                : undefined,
-            })
-          }
-          startIcon={<WriteIcon fontSize="small" />}
-        >
-          Add Retainer
-        </Button>
       </Box>
     </Box>
   )

--- a/components/StudentDialog/SessionDetail.tsx
+++ b/components/StudentDialog/SessionDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Box, Typography, Button } from '@mui/material'
+import { Box, Typography, Button, IconButton, Tooltip } from '@mui/material'
 import { PATHS, logPath } from '../../lib/paths'
 import RateModal from './RateModal'
 import { collection, doc, getDocs, setDoc, Timestamp } from 'firebase/firestore'
@@ -7,6 +7,8 @@ import { getAuth } from 'firebase/auth'
 import { db } from '../../lib/firebase'
 import { useBillingClient, billingKey } from '../../lib/billing/useBilling'
 import { writeSummaryFromCache } from '../../lib/liveRefresh'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import BaseRateHistoryDialog from './BaseRateHistoryDialog'
 
 const formatCurrency = (n: number) =>
   new Intl.NumberFormat(undefined, {
@@ -42,6 +44,7 @@ export default function SessionDetail({
 }: SessionDetailProps) {
   const [voucherUsed, setVoucherUsed] = useState(!!session.voucherUsed)
   const [rateOpen, setRateOpen] = useState(false)
+  const [histOpen, setHistOpen] = useState(false)
   const qc = useBillingClient()
 
   const createVoucherEntry = async (free: boolean) => {
@@ -151,6 +154,11 @@ export default function SessionDetail({
           sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}
         >
           Base Rate:
+          <Tooltip title="Base rate history">
+            <IconButton size="small" onClick={() => setHistOpen(true)}>
+              <InfoOutlinedIcon fontSize="inherit" />
+            </IconButton>
+          </Tooltip>
         </Typography>
         <Typography
           variant="h6"
@@ -205,6 +213,12 @@ export default function SessionDetail({
             Use Session Voucher
           </Button>
         )}
+        <BaseRateHistoryDialog
+          abbr={abbr}
+          account={account}
+          open={histOpen}
+          onClose={() => setHistOpen(false)}
+        />
         <Typography
           variant="subtitle2"
           sx={{ fontFamily: 'Newsreader', fontWeight: 200 }}

--- a/cypress/e2e/dialog_overlay.cy.js
+++ b/cypress/e2e/dialog_overlay.cy.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+/* global cy, describe, it */
+
+describe('Dialog layering', () => {
+  it('shows Add Payment above student dialog', () => {
+    cy.visit('/dashboard/businesses/coaching-sessions')
+    cy.get('[data-testid="student-card"]').first().click()
+    cy.contains('Payment History').click()
+    cy.get('button[aria-label="Add Payment"]').click()
+    cy.get('div[role="dialog"]').should('have.length.at.least', 2)
+  })
+})

--- a/docs/Task Log.md
+++ b/docs/Task Log.md
@@ -1,0 +1,62 @@
+# Task Log
+
+> Single source of truth for prompts (P-###) and engineering tasks (T-###).  
+> Convention: ✅ done, ⏳ in progress, 🧭 next / planned.
+
+Latest change summary
+- Enforced append-only Task Log with CI guard.
+- Add continuous Context Bundle for branch pushes (Issue per branch).
+- Reverted Total Sessions to include cancelled/proceeded like before.
+- Added double-click to auto-size columns to widest visible content; persisted per-user.
+- Unified Balance Due source-of-truth: compute via useBilling, write to billingSummary.balanceDue, card view uses computed value with skeleton fallback.
+- Hardened dialog stacking/portals: "Add Payment" and similar modals always topmost.
+- Added Base Rate History (info icon) with rate, timestamp, editedBy and add-entry flow.
+
+---
+
+Tasks table — add/update:
+
+| ID    | Title                                                | State | Notes / Files |
+|-------|------------------------------------------------------|-------|---------------|
+| T-030 | Task Log guardrails CI & append-only rule | ✅    | docs/Task Log.md, CONTRIBUTING.md, .github/workflows/task-log-guard.yml |
+| T-001 | Column resizing (thin lever, hover, big hit area) + per-user persistence | ✅    | lib/useColumnWidths.ts, .col-resizer |
+| T-002 | Sticky footers for Student Dialog screens (with shadow) | ✅    | .dialog-footer + padding in detail views |
+| T-003 | "Amount Received" blink: infinite + darker yellow (list & detail) | ✅    | .blink-amount |
+| T-004 | PaymentDetail: robust remaining calculation + sticky Assign | ✅    | Remaining = remainingAmount ?? (amount - appliedAmount) |
+| T-005 | Payment list "For Session(s)" by ordinal | ✅    | Uses billing rows to map ordinals |
+| T-006 | Popover/Menu/Select clipping fix inside dialogs | ✅    | Theme defaults to body |
+| T-007 | Sticky, resizable ordinal "#" column in Sessions | ✅    | Sticky first column + resizer |
+| T-008 | Calendar scan integration (UI+API+Apps Script) | ✅    | /api/calendar-scan, tools menu |
+| T-009 | Configure CALENDAR_SCAN_URL in .env.local | 🧭    | Set and restart; add to Vercel envs |
+| T-010 | Apps Script config IDs + services & scopes | 🧭    | COACHING_CALENDAR_ID, FIRESTORE_PROJECT_ID |
+| T-025 | Revert Total Sessions to include cancelled/proceeded | ✅    | SessionsTab summary + card view; ordinal mapping stable |
+| T-026 | Double-click to auto-size column to widest visible content | ✅    | useColumnWidths autoSize() + data-col=... + persisted |
+| T-027 | Balance-due unification and cache write-back | ✅    | Card uses useBilling; writeSummaryFromCache audited |
+| T-028 | Dialog/overlay z-index & portal audit (Add Payment on top) | ✅    | Theme MuiDialog container; remove conflicting z-index |
+| T-029 | Base Rate history modal + add entry (editedBy) | ✅    | Info icon in SessionDetail; new BaseRateHistoryModal |
+| T-011 | Firestore number encoding: doubleValue for non-integers | 🧭    | Update toFirestoreFields |
+| T-012 | Calendar sync 410 recovery (stale syncToken) | 🧭    | Retry full on 410 |
+| T-013 | Add resizers to PaymentDetail headers | 🧭    | Consistency |
+| T-014 | A11y polish for loading/blink | 🧪    | Reduced motion for all blinks |
+| T-015 | Sticky footer regression tour on small viewports | 🧪    | Visual QA |
+| T-016 | Tests for calendar scan endpoints | 🧭    | Node tests |
+| T-017 | Canonicalize Task Log + quick-access link | 🧭    | Readme/menu |
+| T-018 | Remove legacy Batch Rename Payments tool | ✅    | File removed |
+| T-019 | Dropdowns covered by dialog (global audit) | 🧪    | Confirm after theme fix |
+| T-020 | Table perf for large datasets | 🗓️    | Virtualization later |
+| T-021 | Secure /api/calendar-scan | 🧭    | Admin check/secret header |
+| T-022 | Surface scan results/log in UI | 🗓️    | Optional log panel |
+| T-023 | Replace slow-blink placeholders with Skeletons | 🧭    | Card metrics |
+| T-024 | Make scrollbar-in-footer consistent across all tables | 🧪    | Quick sweep |
+
+---
+
+Prompts table — update:
+
+| ID    | Title                                                | State | Notes |
+|-------|------------------------------------------------------|-------|-------|
+| P-017 | Task Log guardrails + finish P-016 acceptance | ✅    | This change |
+| P-011 | Calendar scan integration (Apps Script)              | ✅    | Shipped |
+| P-012 | Resizable tables + sticky # + blink polish           | ✅    | Shipped |
+| P-014 | Session totals revert, auto-size, due unification, dialog audit, base-rate history | ✅    | This change |
+

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -5,7 +5,14 @@ const theme = createTheme({
     MuiPopover: { defaultProps: { container: () => document.body } },
     MuiPopper: { defaultProps: { container: () => document.body } },
     MuiMenu: { defaultProps: { container: () => document.body } },
+    MuiDialog: {
+      defaultProps: {
+        container:
+          typeof window !== 'undefined' ? () => document.body : undefined,
+      },
+    },
   },
+  zIndex: { modal: 1500 },
 });
 
 export default theme;

--- a/pages/api/calendar-scan.ts
+++ b/pages/api/calendar-scan.ts
@@ -6,13 +6,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   try {
     const url = process.env.CALENDAR_SCAN_URL;
+    const secret = process.env.SCAN_SECRET;
     if (!url) {
       return res.status(500).json({ error: 'CALENDAR_SCAN_URL not configured' });
     }
+    const body = req.body || { action: 'scanAll' };
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req.body || { action: 'scanAll' }),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Scan-Secret': secret || '',
+      },
+      body: JSON.stringify(body),
     });
     const data = await response.json();
     if (response.ok) {

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -26,6 +26,7 @@ import { clearSessionSummaries } from '../../../lib/sessionStats'
 import { computeSessionStart } from '../../../lib/sessions'
 import IconButton from '@mui/material/IconButton'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
+import { useBilling } from '../../../lib/billing/useBilling'
 
 interface StudentMeta {
   abbr: string
@@ -44,6 +45,50 @@ const formatCurrency = (n: number) =>
     currency: 'HKD',
     currencyDisplay: 'code',
   }).format(n)
+
+function StudentCard({
+  student,
+  onSelect,
+}: {
+  student: StudentDetails
+  onSelect: (s: StudentDetails) => void
+}) {
+  const { data: bill } = useBilling(student.abbr, student.account)
+  const due = bill?.balanceDue ?? student.balanceDue ?? null
+  return (
+    <Grid item xs={12} sm={6} md={4} lg={3}>
+      <Card>
+        <CardActionArea onClick={() => onSelect(student)}>
+          <CardContent>
+            <Typography variant="h6">{student.account}</Typography>
+            <Typography>
+              <span className={student.sex === undefined ? 'slow-blink' : undefined}>
+                {student.sex ?? '—'}
+              </span>{' '}
+              • Due:{' '}
+              <span className={!bill ? 'slow-blink' : undefined}>
+                {due == null ? '—' : formatCurrency(due)}
+              </span>
+            </Typography>
+            <Typography>
+              Total:{' '}
+              <span className={student.total === undefined ? 'slow-blink' : undefined}>
+                {student.total ?? '—'}
+              </span>
+              {student.upcoming === undefined ? (
+                <span className="slow-blink"> → —</span>
+              ) : student.upcoming > 0 ? (
+                ` → ${student.upcoming}`
+              ) : (
+                ''
+              )}
+            </Typography>
+          </CardContent>
+        </CardActionArea>
+      </Card>
+    </Grid>
+  )
+}
 
 export default function CoachingSessions() {
   const [students, setStudents] = useState<StudentDetails[]>([])
@@ -182,10 +227,18 @@ export default function CoachingSessions() {
 
           // Listen to billing summary updates on the student document
           const unsub = onSnapshot(doc(db, PATHS.student(b.abbr)), (snap) => {
-            const bd = (snap.data() as any)?.billingSummary?.balanceDue
+            const data = snap.data() as any
+            const bd = data?.billingSummary?.balanceDue
+            const totalSessions = data?.totalSessions
             setStudents((prev) =>
               prev.map((s) =>
-                s.abbr === b.abbr ? { ...s, balanceDue: bd ?? null } : s,
+                s.abbr === b.abbr
+                  ? {
+                      ...s,
+                      balanceDue: bd ?? null,
+                      total: totalSessions ?? s.total,
+                    }
+                  : s,
               ),
             )
           })
@@ -220,45 +273,7 @@ export default function CoachingSessions() {
       <Box sx={{ position: 'relative', pb: 8 }}>
         <Grid container spacing={2} sx={{ mt: 2 }}>
           {students.map((s) => (
-            <Grid item key={s.abbr} xs={12} sm={6} md={4}>
-              <Card>
-                <CardActionArea onClick={() => setSelected(s)}>
-                  <CardContent>
-                    <Typography variant="h6">{s.account}</Typography>
-                    <Typography>
-                      <span className={s.sex === undefined ? 'slow-blink' : undefined}>
-                        {s.sex ?? '—'}
-                      </span>
-                      {' '}• Due:{' '}
-                      <span
-                        className={
-                          s.balanceDue === undefined ? 'slow-blink' : undefined
-                        }
-                      >
-                        {s.balanceDue == null
-                          ? '—'
-                          : formatCurrency(s.balanceDue)}
-                      </span>
-                    </Typography>
-                    <Typography>
-                      Total:{' '}
-                      <span
-                        className={s.total === undefined ? 'slow-blink' : undefined}
-                      >
-                        {s.total ?? '—'}
-                      </span>
-                      {s.upcoming === undefined ? (
-                        <span className="slow-blink"> → —</span>
-                      ) : s.upcoming > 0 ? (
-                        ` → ${s.upcoming}`
-                      ) : (
-                        ''
-                      )}
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            </Grid>
+            <StudentCard key={s.abbr} student={s} onSelect={setSelected} />
           ))}
         </Grid>
         <Menu

--- a/prompts/P-014.md
+++ b/prompts/P-014.md
@@ -1,0 +1,222 @@
+P-014 — Session totals revert, column auto-size, balance-due unification, dialog z-index audit, base-rate history
+
+Context / Why
+
+“Total Sessions” regressed: it no longer counts cancelled/proceeded like before.
+
+Column default widths are too wide; we want Google-Sheets-style double-click to auto-size to the widest visible cell.
+
+“Due” on student cards sometimes mismatches vs. Payment/Billing views (and sometimes shows nothing).
+
+“Add payment” dialog can be covered by the student dialog; need a general overlay/z-index/portal hardening pass to prevent any recurrence.
+
+Add a Base Rate audit trail with an info icon next to “Base Rate”, with history + add flow and editedBy.
+
+Scope
+Touch only the web app; keep Apps Script unchanged.
+
+1) Revert “Total Sessions” to previous behavior
+
+Goal
+
+“Total Sessions” in SessionsTab header and the dashboard card must include cancelled and proceeded sessions (i.e., everything that ever existed for the account), like we had before.
+
+Requirements
+
+In components/StudentDialog/SessionsTab.tsx:
+
+Ensure summary.totalSessions is computed from all sessions for the account (cancelled + proceeded + pending), not filtered by period or by flags. (Keep “Period” filter only for the visible table, not for the summary.)
+
+The ordinal (“#”) mapping in Sessions must still align with the full chronology (including cancelled), so when a payment references #N, N is stable.
+
+In pages/dashboard/businesses/coaching-sessions.tsx (student cards):
+
+“Total: X → upcoming” → X must match summary.totalSessions (all sessions). “upcoming” stays as future-dated sessions only.
+
+Acceptance checks
+
+Create a cancelled session and a normal session → total increases by 2, even if one is cancelled.
+
+Changing the Period filter does not change the total.
+
+2) Double-click column lever to auto-size to widest visible content
+
+Goal
+
+Keep the current drag-to-resize, but double-click on the lever should auto-size the column to fit the widest visible cell content (header or body) with a small padding, and persist the width (localStorage) per user.
+
+Implementation notes
+
+lib/useColumnWidths.ts
+
+Add a autoSize(key: string, root: HTMLElement) function:
+
+Query header cell and body cells for that column via a data attribute (e.g., data-col="paymentMade").
+
+Measure natural width via scrollWidth or getBoundingClientRect().width on an inner wrapper (consider text wrapping disabled for measurement).
+
+Compute next = clamp(maxWidth + padding, 60, 1000).
+
+Set width + persist (localStorage).
+
+Expose onDoubleClick handler from the hook: onResizerDoubleClick(key, rootEl).
+
+Tables:
+
+In SessionsTab, PaymentHistory, RetainersTab (and the “For session” table in PaymentDetail), add data-col="<key>" to header and each column’s TableCell.
+
+On the resizer box (.col-resizer), add onDoubleClick={(e) => onResizerDoubleClick(key, tableRootRef.current!)}.
+
+Provide a ref to the table root container so the hook can query descendants.
+
+Accessibility
+
+Cursor remains col-resize.
+
+Keep existing keyboard behavior (no regression).
+
+Acceptance checks
+
+Double-click resizer instantly sizes column to the widest visible content.
+
+Resized width persists on reload (per user).
+
+3) Balance-due: unify source of truth + UI consistency
+
+Goal
+
+Card view “Due” must equal the balance due used in Payment/Retainer/Sessions logic. Avoid blanks / stale cache issues.
+
+Plan
+
+Canonical compute: always compute current balance from useBilling(abbr, account) (client-side truth).
+
+Cache: after any operation that changes money state, write the computed balanceDue into Students/{abbr}.billingSummary.balanceDue (for external consumers).
+
+We already call writeSummaryFromCache(qc, abbr, account) in key flows; audit any misses:
+
+Session rate edit (RateModal)
+
+Voucher mark/unmark
+
+Payment assign/unassign
+
+Retainer add/edit
+
+Calendar resync changes that adjust amounts (if any write path exists)
+
+Card view fix (coaching-sessions.tsx):
+
+Display a skeleton (or the existing slow blink) while useBilling is loading.
+
+When useBilling resolves, use bill.balanceDue for display.
+
+Optionally still listen to billingSummary.balanceDue as a fallback if useBilling failed, but prefer the computed value.
+
+Acceptance checks
+
+Make changes (assign payment, edit rate, voucher) → card “Due” matches Payment view within a refresh cycle; no “—” except while loading.
+
+4) Dialog/overlay z-index & portal audit (fix “Add payment” being covered)
+
+5) The Add Payment and Add Retainer button, and even the page layout for the Retainer tab and the Payment History tab looks not the same as previously deployed, please help revery it back when those button were a 'create' icon like the current session voucher tab
+
+6) Within the selected payment history, it should be the remaining amount that blinks when there's still a remaining amount in value rather than the payment amount
+
+Goal
+
+Any top-level dialog (PaymentModal, RetainerModal, RateModal, etc.) should always overlay the Student Dialog; no clipping or stacking issues.
+
+Implementation
+
+Global theme (we already portaled Popper/Menu/Popover). Extend theme to dialogs:
+
+In lib/theme.ts, add defaults for MuiDialog (ensures body container):
+
+const theme = createTheme({
+  components: {
+    MuiPopover: { defaultProps: { container: () => document.body } },
+    MuiPopper:  { defaultProps: { container: () => document.body } },
+    MuiMenu:    { defaultProps: { container: () => document.body } },
+    MuiDialog:  { defaultProps: { container: typeof window !== 'undefined' ? () => document.body : undefined } },
+  },
+});
+
+Ensure all modals (PaymentModal, RetainerModal, RateModal, any custom modal) are implemented as MUI <Dialog/> (or <Modal/>) with default portal behavior; remove ad-hoc fixed overlays that fight the stack (e.g., hand-rolled fixed <Box> overlays).
+
+If a custom overlay must remain, set sx={{ zIndex: (t) => t.zIndex.modal + 1 }}.
+
+Remove any parent containers with z-index that rises above modal (audit StudentDialog wrappers, keep them at default z-index or below theme.zIndex.modal).
+
+Verify no position: relative + high z-index on dialog content wrappers.
+
+Acceptance checks
+
+From PaymentHistory list, click “Add Payment” → modal always on top.
+
+Test Retainer edits, Rate modal, Select menus, and tooltips inside dialogs—no clipping.
+
+5) Base Rate audit trail + editor
+
+Goal
+
+Next to “Base Rate” label, show an info icon that opens a modal with:
+
+History list (most recent first) with rate, timestamp, editedBy.
+
+Add entry form: rate (number), auto timestamp (now), editedBy (current user email).
+
+On save: append to Students/{abbr}/BaseRateHistory and update the effective base rate field used by default for new sessions (wherever that lives today).
+
+Close modal → latest base rate reflects in SessionDetail and any place that shows “Base Rate”.
+
+Implementation details
+
+Data:
+
+Collection: Students/{abbr}/BaseRateHistory/{autoId}
+
+Document shape: { rate: number, timestamp: serverTimestamp(), editedBy: string }
+
+UI:
+
+In SessionDetail (where “Base Rate” is rendered), append a small IconButton with tooltip (“Base rate history”).
+
+New BaseRateHistoryModal.tsx: lists entries (query orderBy timestamp, desc). Add a simple “Add” section at top.
+
+Auth:
+
+editedBy = useSession().user.email || 'unknown'
+
+Acceptance checks
+
+Add a new history entry → appears at top; effective base rate updates immediately where displayed.
+
+QA checklist
+
+ Total Sessions includes cancelled/proceeded everywhere.
+
+ Double-click to auto-size works in Sessions, Payments, Retainers, and PaymentDetail’s “For session” table.
+
+ Card “Due” matches computed billing; no empty values post-load.
+
+ All dialogs appear above Student Dialog; no clipping of menus/popovers.
+
+ BaseRateHistory works; editedBy saved.
+
+Files you’ll likely touch
+
+components/StudentDialog/SessionsTab.tsx
+
+pages/dashboard/businesses/coaching-sessions.tsx
+
+components/StudentDialog/PaymentHistory.tsx, PaymentDetail.tsx, RetainersTab.tsx
+
+components/StudentDialog/SessionDetail.tsx (+ new BaseRateHistoryModal.tsx)
+
+lib/useColumnWidths.ts
+
+lib/theme.ts
+
+styles/studentDialog.css (if needed for measurement helpers)
+

--- a/prompts/P-015.md
+++ b/prompts/P-015.md
@@ -1,0 +1,161 @@
+P-015 — Code & UX Fixes
+
+Goal: close the gaps called out in PR feedback and our last review:
+
+restore session counts (show proceeded & cancelled like before),
+add double-click auto-fit on column levers,
+fix Balance Due single-source-of-truth,
+make all dialogs layer correctly (no “covered” modals),
+add Base Rate audit trail with editedBy,
+harden calendar scan with a shared secret,
+fix Firestore numeric types in Apps Script.
+
+Scope & acceptance criteria
+A. Sessions summary — restore proceeded/cancelled
+
+In components/StudentDialog/SessionsTab.tsx:
+
+Compute and display:
+
+Total Sessions (includes all sessions),
+Proceeded (= not cancelled & started in the past),
+Cancelled (= flagged cancelled or sessionType cancelled).
+
+Keep existing Joint Date / Last Session.
+
+Ensure table filters (period, visible columns) do not change the summary numbers.
+
+✅ AC: Summary shows Total, Proceeded, Cancelled. Numbers match expectations even when filters change.
+
+B. Column auto-fit on double-click
+
+In lib/useColumnWidths.ts add a autoFit(key: string, root: HTMLElement) function that:
+
+Measures header cell and visible body cells for that column (use scrollWidth), adds padding + min/max clamp (min 60px, max 600px), then persists width.
+
+In each table (SessionsTab, PaymentHistory, RetainersTab, PaymentDetail’s small table):
+
+Add data-col="<key>" on header TableCell and every body TableCell for that column.
+
+On the .col-resizer element add onDoubleClick={() => autoFit('paymentMade', tableRef.current!)} etc.
+
+Provide a ref to the table root (tableRef) to pass into autoFit.
+
+Narrow the default widths a bit (start ~100–140px for most text columns, 70–90px for #/amount-only).
+
+✅ AC: Double-clicking a lever fits to content like Google Sheets; widths persist per user.
+
+C. Balance Due: one source of truth
+
+Treat Students/{abbr}.billingSummary.balanceDue as authoritative.
+
+Audit all mutating flows and call writeSummaryFromCache(qc, abbr, account) after success:
+
+Payment add / assign / unassign (already in PaymentDetail, keep).
+
+Rate changes (in RateModal on save → ensure it calls writeSummaryFromCache).
+
+Voucher mark/unmark (already in SessionDetail via createVoucherEntry, re-confirm and keep).
+
+Retainer add/edit (RetainerModal on save → call writeSummaryFromCache).
+
+In cards (pages/dashboard/businesses/coaching-sessions.tsx), keep reading billingSummary.balanceDue (already hooked).
+
+✅ AC: After any change, the card’s Balance Due updates within the same session (snapshot). There are no discrepancies vs. details.
+
+D. Dialog layering & portals
+
+Convert any custom fixed overlay modals (e.g., RetainerModal) to MUI <Dialog> with open, onClose, and portal to document.body (your theme already sets Menu/Popover/Popper containers).
+
+Ensure PaymentModal is also a MUI Dialog and not nested inside a container that creates a stacking context (no parent with transform, filter, or opacity<1 that might trap z-index).
+
+Keep sticky footers; do not increase z-index beyond MUI’s defaults (Dialog = 1300+).
+
+Add a quick Cypress test: open Student dialog → open Add Payment → assert the Add Payment dialog is visible above the student dialog.
+
+✅ AC: Add Payment dialog never gets covered; same for similar dialogs.
+
+E. Base Rate audit trail (+editedBy)
+
+Where “Base Rate” is shown (Session detail and/or relevant settings UI), add a small Info icon (InfoOutlined) next to the label.
+
+Clicking opens a Base Rate History dialog:
+
+Firestore path: Students/{abbr}/BaseRateHistory/{id}.
+
+Fields: rate (number), timestamp (server or client Date), editedBy (string; from next-auth session user email).
+
+Show a small table of entries (latest first) and an “Add new rate” form (rate input).
+
+On add, also call writeSummaryFromCache(qc, abbr, account) so derived fields stay current.
+
+✅ AC: History lists prior entries; adding a new rate writes rate, timestamp, editedBy and updates summaries.
+
+F. Secure the calendar scan endpoint
+
+Apps Script (apps-script/ScanEndpoint.gs):
+
+Store SCAN_SECRET in Script Properties (File → Project properties → Script properties).
+
+In doPost(e), require body.secret === scriptProps.getProperty('SCAN_SECRET'). If not, return { ok:false, message:'unauthorized' } (HTTP 401 if you like).
+
+Next.js (pages/api/calendar-scan.ts):
+
+Read process.env.CALENDAR_SCAN_URL and process.env.CALENDAR_SCAN_SECRET.
+
+Always include { secret: process.env.CALENDAR_SCAN_SECRET, ...existingBody } in the POST body.
+
+✅ AC: Calls without the correct secret are rejected by Apps Script.
+
+G. Firestore numeric types in Apps Script
+
+In apps-script/Firestore.gs → toFirestoreFields:
+
+For numbers, use:
+} else if (typeof val === 'number') {
+  if (Math.floor(val) === val) {
+    fields[key] = { integerValue: String(val) };
+  } else {
+    fields[key] = { doubleValue: val };
+  }
+}
+
+✅ AC: Decimals are written as doubleValue. Integers remain integerValue.
+
+Implementation notes
+
+Add data-col consistently: e.g., in SessionsTab for ordinal, date, time, etc.; in PaymentHistory add for paymentMade, amount, session; in RetainersTab for retainer, period, rate, status, actions; in PaymentDetail table for ordinal, date, time, rate.
+
+Provide a shared TableRoot ref to pass into autoFit.
+
+Keep the slimmer .col-resizer lever (already done); simply bind onDoubleClick now.
+
+After retainer save & rate save, make sure we call writeSummaryFromCache(...) and close the dialog.
+
+Config changes
+
+.env.local (and Vercel env):
+
+CALENDAR_SCAN_URL="https://script.google.com/macros/s/AKfycbzESImrT9yROHCEq0HFM70mGNLd_x-HYT-nJ1E9X_urFxxOPKi3XYqHZW79bGk3tqgFZA/exec"
+CALENDAR_SCAN_SECRET="<choose-a-long-random-string>"
+
+Apps Script → Script Properties:
+
+SCAN_SECRET=<same-long-random-string>
+
+Test plan
+
+Sessions summary: Load a student with a known cancelled event + past completed event → see Total, Proceeded, Cancelled counts correct. Toggle filters → counts unchanged.
+
+Auto-fit: Manually shrink a column, double-click its lever → fits to widest visible content. Refresh → width persists.
+
+Balance Due: Change a rate, mark voucher, assign payment, add retainer → card value matches details immediately.
+
+Dialogs: Open Student dialog → open Add Payment → visually on top; run the Cypress spec.
+
+Base Rate history: Add a new rate → entry includes editedBy; derived summaries refresh.
+
+Scan security: Call /api/calendar-scan with wrong secret (temporarily) → Apps Script rejects. With correct secret → works.
+
+Numeric types: Write a decimal rate via Apps Script flow → stored as doubleValue (spot-check in Firestore REST view).
+

--- a/prompts/P-016.md
+++ b/prompts/P-016.md
@@ -1,0 +1,92 @@
+# P-016 — Autosize columns, session totals parity, balance due source, modal stacking fix, base rate audit, scan security/timezone
+
+## Goals
+1) Double-click autosize for table columns (Sessions, Retainers, Payments).
+2) Show **Total Sessions** including cancelled/proceeded (as it used to).
+3) Make **Balance Due** consistent between card view and dialog by using the **same** source of truth.
+4) Fix dialog stacking so “Add Payment” (and similar) never hides behind the Student dialog.
+5) Add **Base Rate** audit trail (view & add) incl. `editedBy`.
+6) GAS: set proper timezone and secure the scan endpoint with a shared secret.
+
+---
+
+## 1) Column autosize on double-click
+- File: `lib/useColumnWidths.ts`
+  - Add an `autoSize(key: string, rootEl: HTMLElement)` function that:
+    - Measures header cell text width **and** all visible body cells for that column (use a hidden off-screen measurer or temporarily set `width: auto` on clones).
+    - Adds padding for cell gutters + a small buffer (e.g. +16–24px).
+    - Clamps between 60 and 600.
+    - Updates `widths[key]` and persists to localStorage as today.
+  - Export `onDblClick` handler: `dblClickResize(key, e)` → calls `autoSize`.
+- Files:
+  - `components/StudentDialog/SessionsTab.tsx`
+  - `components/StudentDialog/RetainersTab.tsx`
+  - `components/StudentDialog/PaymentHistory.tsx`
+    - On each `.col-resizer` add `onDoubleClick={(e) => dblClickResize('<colKey>', e)}`.
+- Acceptance:
+  - Double-clicking a lever snaps to fit widest visible content; drag still works; persisted per user/table.
+
+## 2) Total Sessions parity (include cancelled/proceeded)
+- File: `components/StudentDialog/SessionsTab.tsx`
+  - When computing `summary.totalSessions`, **do not** exclude cancelled/proceeded. Count all sessions in the time window (as before).
+  - Optional (nice to have): in the header summary row, show a small breakdown:  
+    `Total Sessions: N  •  Cancelled: C  •  Proceeded: P`
+- Acceptance:
+  - Count matches the old behavior; cancelled/proceeded no longer disappear from the total.
+
+## 3) Balance Due single source of truth
+- Preferred source: `useBilling(abbr, account)` summary (computed live) **or** a single canonical summary doc that `writeSummaryFromCache` always updates.
+- File: `pages/dashboard/businesses/coaching-sessions.tsx`
+  - Replace reliance on `Students/{abbr}.billingSummary.balanceDue` if it lags. Either:
+    - a) Use `useBilling` for each card (batched or lazy on expand), OR
+    - b) Read `Students/{abbr}/Billing/Summary` (single doc) that is updated whenever sessions/payments/retainers change.
+- Ensure `writeSummaryFromCache(qc, abbr, account)` is called on **every** mutation path that affects money:
+  - Already present in: payment assignment, voucher mark/unmark, retainer payment; verify in `SessionDetail`, `PaymentDetail`, retainer flows.
+- Acceptance:
+  - Card “Due” and dialog “Balance Due” always match after any change; no “—” unless truly loading.
+
+## 4) Modal stacking audit (Payment/Retainer and peers)
+- Convert custom overlays to true MUI `Dialog` or ensure portal + higher z-index:
+  - Files:
+    - `components/StudentDialog/PaymentModal.tsx` (ensure it is a MUI `Dialog` with `open`/`onClose` and **portals to body**).
+    - `components/StudentDialog/RetainerModal.tsx` (same).
+  - If keeping custom overlay, wrap content in `<Portal container={document.body}>` and set `z-index` above the parent Dialog (>= `theme.zIndex.modal`, e.g. 1500).
+- Theme:
+  - File: `lib/theme.ts`
+    - We already set Popper/Menu containers; add explicit `zIndex: { modal: 1500 }` if needed.
+- Acceptance:
+  - “Add Payment” and similar dialogs never appear beneath the Student dialog; keyboard focus is correct.
+
+## 5) Base Rate audit trail
+- UI:
+  - In `SessionDetail.tsx`, next to **Base Rate**, add an `IconButton` (info icon). Clicking opens `BaseRateHistoryDialog`.
+- New: `components/StudentDialog/BaseRateHistoryDialog.tsx`
+  - Lists entries sorted desc: `{ rate: number, timestamp: Timestamp, editedBy: string }`
+  - “Add entry” allows setting a rate (number) → writes a new doc with `editedBy = session.user.email || 'unknown'`.
+- Data:
+  - Collection path proposal: `Students/{abbr}/BaseRateHistory` (per student). If per account, include `account` in path or as a field.
+- Acceptance:
+  - View shows history; adding creates a new entry with `editedBy` captured.
+
+## 6) Apps Script hardening (timezone + secret)
+- File: `apps-script/CONFIG.gs`
+  - Set `TIMEZONE` to `'Asia/Hong_Kong'` **or** compute from `Session.getScriptTimeZone()` if accessible; otherwise make it a Script Property and read it.
+- Security (Apps Script):
+  - In `ScanEndpoint.gs#doPost`, require header `X-Scan-Secret`. Compare with a Script Property `SCAN_SECRET`; reject missing/mismatched.
+- Next.js API:
+  - File: `pages/api/calendar-scan.ts`
+    - Read `process.env.SCAN_SECRET` and send `X-Scan-Secret` header to GAS.
+- Docs / env:
+  - File: `.env.local.example` (or README)
+    ```
+    CALENDAR_SCAN_URL="https://script.google.com/macros/s/AKfycbzESImrT9yROHCEq0HFM70mGNLd_x-HYT-nJ1E9X_urFxxOPKi3XYqHZW79bGk3tqgFZA/exec"
+    SCAN_SECRET="choose-a-long-random-string"
+    ```
+- Acceptance:
+  - Scan fails with 401 if secret absent/wrong; successful otherwise. Timestamps formatted for HK.
+
+## Regression checklist
+- Column drag/resize still works and persists.
+- Payments “Amount Received” still blinks when remaining > 0 / none assigned (both list + detail).
+- Sticky footers intact; sticky ordinal column intact.
+- “For Session(s)” still shows # ordinals.

--- a/prompts/p-017.md
+++ b/prompts/p-017.md
@@ -1,0 +1,70 @@
+# P-017 — Task Log guardrails + finish P-016 acceptance (autosize, session totals, balance due, modal stacking, base-rate audit, scan security)
+
+> Save this exact prompt to: `prompts/p-017.md` in the repo.
+
+## A. Task Log guardrails (finish the HOTFIX)
+1) Ensure `docs/Task Log.md` is restored from `main` and is **append-only**.
+2) Add CI check: `.github/workflows/task-log-guard.yml`
+   - Job: fetch `origin/main`, compute line count of `docs/Task Log.md` at `HEAD` vs `origin/main`. Fail if decreased by >10 lines.
+3) Update `CONTRIBUTING.md` with the append-only rule and the “new rows at the top” convention.
+
+## B. Double-click autosize for columns (Sessions/Retainers/Payments)
+- File: `lib/useColumnWidths.ts`
+  - Add `dblClickResize(key: string, rootEl?: HTMLElement)` that:
+    - Measures widest visible cell in that column (header + body). Use an off-screen measurer div with same font styles.
+    - Adds padding buffer (e.g. +20px) and clamps (min 60px, max 600px).
+    - Updates `widths[key]` and persists.
+- Wire up `onDoubleClick` on each `.col-resizer`:
+  - `components/StudentDialog/SessionsTab.tsx`
+  - `components/StudentDialog/RetainersTab.tsx`
+  - `components/StudentDialog/PaymentHistory.tsx`
+- Acceptance: double-click lever fits to content quickly (no visible layout jank); drag-resize still works and persists.
+
+## C. “Total Sessions” parity (include cancelled/proceeded)
+- `components/StudentDialog/SessionsTab.tsx`:
+  - Recompute `summary.totalSessions` to include **all** sessions in the active window (as it used to), including cancelled/proceeded.
+  - (Nice) Show a small breakdown: `Total: N • Cancelled: C • Proceeded: P`.
+- Acceptance: totals match legacy behavior; tests/manual checks show parity.
+
+## D. Balance-Due single source of truth
+- Canonicalize Reads:
+  - Option 1 (preferred): source from `useBilling(abbr, account)` summary for both **cards** (`coaching-sessions.tsx`) and **dialogs**.
+  - Option 2: maintain `Students/{abbr}/Billing/Summary` doc that `writeSummaryFromCache` updates; read this in both places.
+- Ensure every mutation path calls `writeSummaryFromCache`:
+  - Payment assignment/unassignment, voucher mark/unmark, rate edits, retainer payments.
+- Acceptance: Card “Due” matches dialog “Balance Due” after any change; no stale “—” except while loading.
+
+## E. Modal stacking (Payment/Retainer/etc.)
+- Convert overlays to MUI `Dialog` (or ensure `<Portal container={document.body}>` with `zIndex` > parent dialog).
+- Files to verify:
+  - `components/StudentDialog/PaymentModal.tsx`
+  - `components/StudentDialog/RetainerModal.tsx`
+  - Anywhere else we use custom overlay.
+- Theme: if needed, set `theme.zIndex.modal >= 1500` and ensure controlling dialogs get higher `z-index` than parent.
+- Acceptance: “Add Payment” (and peers) always appear above Student dialog; focus trap and ESC close work.
+
+## F. Base-Rate audit trail
+- Add an info icon next to “Base Rate” in `SessionDetail.tsx` that opens `BaseRateHistoryDialog`.
+- New: `components/StudentDialog/BaseRateHistoryDialog.tsx`
+  - List history entries `{ rate: number, timestamp: Timestamp, editedBy: string }` (desc).
+  - “Add entry” form writes a new record with `editedBy = session.user.email || 'unknown'`.
+  - Suggested path: `Students/{abbr}/BaseRateHistory` (or per-account if required).
+- Acceptance: view/add history works; `editedBy` captured.
+
+## G. Apps Script hardening (timezone + shared secret)
+- `apps-script/CONFIG.gs`: set `TIMEZONE` to `'Asia/Hong_Kong'` (or read Script Property).
+- `apps-script/ScanEndpoint.gs`:
+  - Require header `X-Scan-Secret`; compare to Script Property `SCAN_SECRET`. Return 401 on mismatch.
+- `pages/api/calendar-scan.ts`:
+  - Send `X-Scan-Secret` from `process.env.SCAN_SECRET`.
+- `.env.local.example`:
+```
+CALENDAR_SCAN_URL="https://script.google.com/macros/s/AKfycbzESImrT9yROHCEq0HFM70mGNLd_x-HYT-nJ1E9X_urFxxOPKi3XYqHZW79bGk3tqgFZA/exec"
+SCAN_SECRET="choose-a-long-random-string"
+```
+- Acceptance: scan returns 401 without/with wrong secret; OK with correct secret; HK timestamps.
+
+## H. QA & docs
+- Add/refresh inline comments near touched areas.
+- Update `README` (env vars) and `docs/Task Log.md` (see P-017 update prompt).
+


### PR DESCRIPTION
## Summary
- enforce append-only Task Log with a CI guard and CONTRIBUTING guide
- refine column autosize with table-aware double‑click handling
- document calendar scan env vars and log new requirements in `prompts/p-017.md`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npx cypress run --spec cypress/e2e/dialog_overlay.cy.js` *(requires install: cypress@14.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_689f8247acb4832398de585c33c1df13