### PR TITLE
docs: log new tasks and prompt

### DIFF
--- a/docs/Task Log.md
+++ b/docs/Task Log.md
@@ -19,6 +19,16 @@ Latest change summary
 Tasks table — add/update:
 
 | ID    | Title                                                | State | Notes / Files |
+| T-045 | Base rate SSOT: derive by `effectDate` (HK midnight) for sessions     |       | Apply when computing/reading Base Rate across UI & billing; fallback: if missing, treat `effectDate = startOfDay(timestamp, HK)`; add migration util |
+| T-046 | Base Rate History: edit existing entries (rate & effectDate) + audit  |       | BaseRateHistoryDialog: inline edit w/ validation; write `editedBy`; keep `timestamp` as entry time; no “Edited By” column (show in tooltip) |
+| T-047 | Base Rate History: “transit line” visualization (toggle view)         |       | Dialog toggle between table and timeline; responsive; keyboard accessible |
+| T-048 | Sessions summary naming/layout: label “Total Sessions”, value layout  |       | Revert label; move values off title line; Show `Total Sessions: N (❌ C)`; no value embedded in label |
+| T-049 | Sessions summary hover swap → show ✔︎ proceeded on hover (no tooltip) |       | Replace tooltip with on-hover value swap to ✔︎ (N−C); revert on mouseout; reduced-motion safe |
+| T-050 | Card view “Total” = proceeded (total − cancelled)                      |       | Dashboard cards: display proceeded count; upcoming arrow unchanged; align with Sessions summary |
+| T-051 | Column min-width squeeze v2 (~28–32px) + ellipsis + a11y tooltip       |       | `lib/useColumnWidths.ts`, table cell styles; ensure keyboard resizing; sticky ordinal width review |
+| T-052 | billingSummary → cached.billingSummary (double-write + migration)     |       | Writers update both; readers prefer cached; add backfill script and deprecation note |
+| T-053 | Payment History blink logic QA/tests                                   |       | Ensure yellow blink when remaining>0; red blink when remaining<min unpaid; cypress + reduced-motion |
+| T-054 | Base Rate “Rate (HKD)” label + currency rendering (finalize)          |       | Keep explicit in dialog columns; format as $X,XXX; cover edge cases |
 | T-031 | Column min-width squeeze & ellipsis | 🧭    | lib/useColumnWidths.ts; components |
 | T-032 | Sessions summary tooltip format | 🧭    | SessionsTab.tsx, OverviewTab.tsx |
 | T-033 | Payment History blink logic | 🧭    | PaymentHistory.tsx, styles |
@@ -70,7 +80,7 @@ Tasks table — add/update:
 Prompts table — update:
 
 | ID    | Title                                                | State | Notes |
-| P-019 | Column min-width squeeze, sessions summary regression fix, payment blink logic, base rate history redesign | 🧭    | See `prompts/P-019.md` |
+| P-020 | Base Rate effectDate SSOT, summary naming/hover, card Total, min-width v2, cached.billingSummary, tests |        | Will implement T-045..T-054 |
 |-------|------------------------------------------------------|-------|-------|
 | P-019 | Min-width squeeze, T-217 display, payment blink logic, Base Rate history redesign         | 🧭    | This change |
 | P-018 | Context Bundle automation, payment summary write, overlay test hardening, README link fix | ✅    | This change |


### PR DESCRIPTION
## Summary
- log tasks T-045 through T-054 for upcoming base rate and session updates
- note upcoming prompt P-020 for these tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1cedc708323b4dab4969d5ce554