### PR TITLE
add P-020 prompt

### DIFF
--- a/prompts/P-020.md
+++ b/prompts/P-020.md
@@ -1,0 +1,118 @@
+P-020 — Base Rate effectDate SSOT, Sessions summary rename/hover swap, card “Total”=proceeded, min-width v2, cached.billingSummary migration, payment blink QA, Base Rate History edit + viz
+
+Save this exact prompt to: prompts/P-020.md
+Do not edit docs/Task Log.md in this PR. A separate Task-Log prompt will handle updates.
+In your PR description/comment, include a Context Bundle: what changed, why, files touched, test steps, and screenshots/GIFs.
+
+Goals (maps to T-045 … T-054)
+1. SSOT for session Base Rate via effectDate (HK midnight boundary).
+2. Base Rate History: editing (rate & effective date), audit, and UX polish.
+3. Optional “transit line” visualization for Base Rate History (toggle).
+4. Sessions summary: label = “Total Sessions”, values off the title line.
+5. Hover swap: when hovering “Total Sessions” value, show ✔︎ proceeded count (no tooltip).
+6. Card view: “Total” shows proceeded (all − cancelled).
+7. Column min-width v2: allow ~28–32px with ellipsis + a11y tooltip, keyboard resize.
+8. billingSummary → cached.billingSummary with double-write + migration.
+9. Payment History blink QA: yellow if remaining>0, red if remaining < min unpaid rate.
+10. Keep “Rate (HKD)” label + currency formatting everywhere.
+
+⸻
+
+Implementation notes
+
+A) Base Rate SSOT by effectDate (T-045)
+• Rule: for any session at session.startMs, pick the latest Base Rate History entry whose effectDate <= startMs (compare in Asia/Hong_Kong, date-only at 00:00:00).
+• Fallback: if an entry is missing effectDate, treat effectDate = startOfDay(timestamp, HK); show a blinking “–” in the dialog and allow inline edit to set it.
+• Where to apply:
+• The compute path used by useBilling(abbr, account) (or equivalent) that sets row.baseRate.
+• SessionDetail and any place that renders “Base Rate”.
+• Time zone: use dayjs + dayjs-timezone (Asia/Hong_Kong), normalize both the session date and entry effectDate to HK midnight when comparing.
+
+B) Base Rate History — edit & UX (T-046, T-054)
+• Dialog changes:
+• Column header: “Rate (HKD)”; render as currency $X,XXX.
+• Remove the Edited By column. On row hover, show tooltip “Edited by {email} on {timestamp}”.
+• If an entry has no effectDate, show a blinking “–” in the Effective Date column; clicking it opens inline date edit.
+• Add/Edit flows:
+• Move Add button to the dialog footer left; keep Close on the right.
+• Clicking Add opens a small sub-dialog with:
+• New Rate (number)
+• Effective Date (date-only). Default to today in HK; on save, store at 00:00:00 HK.
+• Add Edit affordance per row to change rate and/or effective date.
+• Persist fields:
+• rate (number),
+• effectDate (timestamp at 00:00:00 HK),
+• timestamp (entry creation time, keep as-is),
+• editedBy (current user email).
+• After add/edit, refresh the list and call any summary writer you already use (no need to recalc full history server-side).
+
+C) Base Rate History “transit line” viz (T-047)
+• Add a toggle within the dialog between Table and Timeline.
+• Timeline: chronological left→right (or top→bottom), each “stop” shows date+rate; ensure keyboard focus order and screen-reader labels.
+• Persist last chosen view (localStorage).
+
+D) Sessions summary naming & layout (T-048, T-049)
+• Revert label to “Total Sessions”.
+• Keep value below the label (don’t print values in the title line).
+• Show Total Sessions: N (❌ C) in the value area.
+• Hover behaviour: while pointer is over the value, swap the shown number to ✔︎ proceeded = N−C (no tooltip). On mouseleave, restore.
+• Respect prefers-reduced-motion: if true, don’t animate; just swap text.
+
+E) Card view “Total” = proceeded (T-050)
+• On the dashboard student cards, the “Total” value should be N−C (exclude cancelled). Keep the → upcoming indicator unchanged.
+
+F) Column min-width v2 + a11y (T-051)
+• In lib/useColumnWidths.ts, lower the min clamp to 28–32px.
+• Cells: set white-space: nowrap; text-overflow: ellipsis; overflow: hidden; and put the full text in a tooltip/title attribute for both hover and focus.
+• Add keyboard resize on the resizer handle: when focused, ArrowLeft/Right shrink/expand by, say, 8px.
+
+G) billingSummary → cached.billingSummary (T-052)
+• Writers (e.g., writeSummaryFromCache) should double-write both:
+• Students/{abbr}.billingSummary (legacy), and
+• Students/{abbr}.cached.billingSummary (new).
+• Readers prefer cached.billingSummary when present; otherwise fallback to legacy.
+• Add a small Node script scripts/backfillCachedBillingSummary.ts to copy legacy → cached for existing docs (non-destructive).
+• Add a README note marking billingSummary deprecated.
+
+H) Payment History blink logic (T-053)
+• In the table rows:
+• Yellow blink if remainingAmount > 0.
+• Red blink if remainingAmount < minUnpaidRate, where minUnpaidRate is computed from unpaid sessions not covered by vouchers/retainers.
+• Respect prefers-reduced-motion: disable blinking and use a static highlight style.
+
+I) Keep “Rate (HKD)” label & currency formatting (T-054)
+• Ensure all Base Rate History rate displays render as currency with HKD.
+
+⸻
+
+Tests & acceptance
+• Base Rate SSOT: a session on 2025-01-15 uses the most recent history with effectDate <= 2025-01-15 00:00 HK. Changing an older entry’s effectDate reassigns affected sessions.
+• Missing effectDate: shows blinking “–”; inline edit saves; row updates; sessions re-derive correctly.
+• Summary UX: label says “Total Sessions”; hovering the number swaps to ✔︎ proceeded; leaving restores.
+• Card Total: equals proceeded (N−C) and matches Sessions summary.
+• Min-width: columns can shrink to ~30px, content ellipsizes, tooltip shows full value; resizer responds to keyboard.
+• Cached summary: writers update both locations; readers prefer cached; backfill script runs without data loss.
+• Blink QA: yellow/red logic matches remaining threshold; reduced-motion disables blinking.
+• Transit line: toggle works; screen-reader announces each stop with date+rate.
+
+⸻
+
+Files you’ll likely touch
+• components/StudentDialog/BaseRateHistoryDialog.tsx (+ small sub-dialogs for Add/Edit)
+• components/StudentDialog/SessionsTab.tsx (summary label/layout/hover; baseRate derive hook usage)
+• components/StudentDialog/PaymentHistory.tsx (blink logic)
+• components/StudentCard or pages/dashboard/businesses/coaching-sessions.tsx (card “Total”)
+• lib/useColumnWidths.ts (min clamp + keyboard resize)
+• lib/billing/useBilling.ts (or wherever base rates are computed for rows)
+• lib/time.ts (dayjs tz helpers)
+• scripts/backfillCachedBillingSummary.ts
+• README.md (deprecation note)
+
+⸻
+
+PR checklist (please include in the PR description)
+• Context Bundle: summary, before/after screenshots, and test steps.
+• Manual test matrix covers all acceptance bullets above.
+• New code respects prefers-reduced-motion.
+• No changes to docs/Task Log.md in this PR.
+• Added/updated Cypress/unit tests where it’s meaningful.


### PR DESCRIPTION
## Summary
- add prompt P-020 with detailed implementation goals and testing checklist

## Context Bundle
- **What changed:** Added new task prompt file
- **Why:** Track requirements for Base Rate effectDate SSOT and related UI/logic updates
- **Files touched:** `prompts/P-020.md`
- **Test steps:**
  - `npm test` *(fails: Missing script: "test")*
  - `npm run lint`
- **Screenshots/GIFs:** N/A


------
https://chatgpt.com/codex/tasks/task_e_68a0c2b767148323869f5c4e836424b2