### PR TITLE
Add context bundle link workflow

### DIFF
--- a/.github/workflows/context-bundle-link.yml
+++ b/.github/workflows/context-bundle-link.yml
@@ -1,0 +1,89 @@
+name: Context Bundle Link
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  post-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upsert Context Bundle link comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const num = pr.number;
+            const headRepo = pr.head.repo.full_name;
+            const headSha  = pr.head.sha;
+            const baseRepo = pr.base.repo.full_name;
+            const path = `docs/context/PR-${num}.md`;
+            const raw = `https://raw.githubusercontent.com/${headRepo}/${headSha}/${path}`;
+            const pretty = `https://github.com/${headRepo}/blob/${headSha}/${path}`;
+            const indexRaw = `https://raw.githubusercontent.com/${baseRepo}/main/docs/context/index.md`;
+
+            // Check if file exists at head SHA
+            let exists = false;
+            try {
+              await github.rest.repos.getContent({
+                owner: headRepo.split('/')[0],
+                repo: headRepo.split('/')[1],
+                path,
+                ref: headSha
+              });
+              exists = true;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            const marker = '<!-- context-bundle-link -->';
+            const bodyWhenExists =
+            `${marker}
+            **Context Bundle:**
+            • Raw: ${raw}
+            • View: ${pretty}
+
+            _Index:_ ${indexRaw}
+            `;
+            const bodyWhenMissing =
+            `${marker}
+            _Context bundle not found at_ \`${path}\` _for this commit yet._
+            Please push it to this branch and re-run the workflow.
+            `;
+
+            // Find existing bot comment with marker
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+              per_page: 100
+            });
+
+            const mine = comments.find(c =>
+              c.user?.type === 'Bot' &&
+              typeof c.body === 'string' &&
+              c.body.includes(marker)
+            );
+
+            const body = exists ? bodyWhenExists : bodyWhenMissing;
+
+            if (mine) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: mine.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: num,
+                body
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,8 @@
 - Never remove lines; only append new entries.
 
 Please run `npm run lint` and `npm run build` before submitting a pull request.
+
+## Context Bundle
+
+- Commit the bundle at `docs/context/PR-<num>.md` on the PR branch.
+- The bot will post or update one comment with the raw & view links (plus optional index).


### PR DESCRIPTION
## Summary
- add workflow that upserts a comment linking to the context bundle for each PR
- document context bundle comment behavior in Contributing guide

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e65ca5088323a0f4e30d310a2940