### PR TITLE
feat(payment): ERL cascade wired to bankAccount structure, side-by-side selects, detail fallback, single badge, alignment (P-027-08r)

### DIFF
--- a/components/StudentDialog/PaymentDetail.test.tsx
+++ b/components/StudentDialog/PaymentDetail.test.tsx
@@ -83,6 +83,9 @@ describe('PaymentDetail', () => {
         onBack={() => {}}
       />,
     )
+    fireEvent.change(screen.getByTestId('detail-method-select'), {
+      target: { value: 'FPS' },
+    })
     fireEvent.change(screen.getByTestId('detail-entity-select'), {
       target: { value: 'Music Establish (ERL)' },
     })
@@ -104,10 +107,13 @@ describe('PaymentDetail', () => {
     await waitFor(() =>
       expect(payment.entity).toBe('Music Establish (ERL)'),
     )
+    expect(payment.method).toBe('FPS')
     expect(payment.bankCode).toBe('001')
     expect(payment.accountDocId).toBe('A1')
     expect(payment.identifier).toBe('001/A1')
     expect(payment.refNumber).toBe('REF1')
+    expect(screen.queryByTestId('detail-method-select')).toBeNull()
+    expect(screen.queryByTestId('detail-entity-select')).toBeNull()
   })
 })
 

--- a/lib/erlDirectory.test.ts
+++ b/lib/erlDirectory.test.ts
@@ -1,4 +1,19 @@
-import { buildBankLabel } from './erlDirectory'
+import {
+  buildBankLabel,
+  listBanks,
+  listAccounts,
+} from './erlDirectory'
+import { collection, collectionGroup, getDocs } from 'firebase/firestore'
+
+jest.mock('./firebase', () => ({ app: {} }))
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  initializeFirestore: jest.fn(() => ({})),
+  collection: jest.fn((_: any, ...parts: string[]) => parts.join('/')),
+  collectionGroup: jest.fn((_: any, id: string) => `group:${id}`),
+  getDocs: jest.fn(),
+}))
 
 describe('buildBankLabel', () => {
   test('uses name and code when available', () => {
@@ -11,5 +26,90 @@ describe('buildBankLabel', () => {
     expect(
       buildBankLabel({ bankCode: '012', docId: 'd1', collectionId: 'banks' }),
     ).toBe('d1 banks')
+  })
+})
+
+describe('listBanks', () => {
+  beforeEach(() => {
+    ;(getDocs as jest.Mock).mockReset()
+    ;(collection as jest.Mock).mockClear()
+  })
+
+  test('returns banks collection when present', async () => {
+    ;(getDocs as jest.Mock).mockResolvedValueOnce({
+      docs: [
+        { id: 'b1', data: () => ({ code: '001', name: 'Bank1' }) },
+      ],
+    })
+    const res = await listBanks()
+    expect(collection).toHaveBeenCalledWith(expect.anything(), 'banks')
+    expect(res).toEqual([
+      {
+        bankCode: '001',
+        bankName: 'Bank1',
+        docId: 'b1',
+        collectionId: 'banks',
+      },
+    ])
+  })
+
+  test('falls back to bankAccount collection using code field', async () => {
+    ;(getDocs as jest.Mock)
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({
+        docs: [
+          { id: 'Dah Sing Bank', data: () => ({ code: '(040)' }) },
+        ],
+      })
+    const res = await listBanks()
+    expect(collection).toHaveBeenCalledWith(expect.anything(), 'bankAccount')
+    expect(res).toEqual([
+      {
+        bankCode: '(040)',
+        bankName: 'Dah Sing Bank',
+        docId: 'Dah Sing Bank',
+        collectionId: 'bankAccount',
+      },
+    ])
+  })
+})
+
+describe('listAccounts', () => {
+  beforeEach(() => {
+    ;(getDocs as jest.Mock).mockReset()
+    ;(collection as jest.Mock).mockClear()
+    ;(collectionGroup as jest.Mock).mockClear()
+  })
+
+  test('returns accounts under banks/{code} when present', async () => {
+    ;(getDocs as jest.Mock).mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: 'a1', data: () => ({ accountType: 'chk' }) }],
+    })
+    const res = await listAccounts('001')
+    expect(collection).toHaveBeenCalledWith(
+      expect.anything(),
+      'banks',
+      '001',
+      'accounts',
+    )
+    expect(res).toEqual([{ accountDocId: 'a1', accountType: 'chk' }])
+  })
+
+  test('falls back to collection group on code', async () => {
+    ;(getDocs as jest.Mock)
+      .mockResolvedValueOnce({ empty: true, docs: [] })
+      .mockResolvedValueOnce({
+        docs: [
+          {
+            id: 'acc1',
+            data: () => ({ accountType: 'sv' }),
+            ref: { path: '/bankAccount/DSB/(040)/acc1' },
+          },
+        ],
+      })
+    const res = await listAccounts('(040)')
+    expect(collectionGroup).toHaveBeenCalledWith(expect.anything(), '(040)')
+    expect(res).toEqual([{ accountDocId: 'acc1', accountType: 'sv' }])
   })
 })

--- a/pages/dashboard/businesses/coaching-sessions.tsx
+++ b/pages/dashboard/businesses/coaching-sessions.tsx
@@ -430,6 +430,7 @@ export default function CoachingSessions() {
             sx={{
               bgcolor: serviceMode ? 'red' : 'primary.main',
               animation: serviceMode ? 'blink 1s infinite' : 'none',
+              height: 36,
             }}
           >
             Service Mode

--- a/prompts/p-027-08r.md
+++ b/prompts/p-027-08r.md
@@ -1,0 +1,44 @@
+# P-027-08r — Wire ERL cascade to current Firestore structure, side-by-side selects, add cascade to Payment Detail (when empty), keep single badge & alignment
+
+## Save path
+prompts/p-027-08r.md
+
+## Branch & PR
+- Branch: codex/finalize-add-payment-cascade-and-alignments-08r
+- PR title: feat(payment): ERL cascade wired to bankAccount structure, side-by-side selects, detail fallback, single badge, alignment (P-027-08r)
+- Labels: payments, ui, codex
+- Do not change CI, Actions, or Vercel settings in this PR.
+
+## A) ERL directory hookup (no new helpers, adapt existing files)
+- Update lib/erlDirectory.ts to read new `erl-directory/bankAccount/{BankName}` docs that require a `code` field.
+- listBanks(): prefer `banks/*`; fallback to `bankAccount/*` using `data.code`.
+- listAccounts(bankCode): prefer `banks/{bankCode}/accounts/*`; fallback via `collectionGroup(dbDirectory, bankCode)` filtering paths containing `/bankAccount/`.
+- buildBankLabel unchanged.
+- Missing `code` on bank docs should surface a toast and inline hint in the UI.
+
+## A2. Add Payment dialog — keep cascade, make it actually populate
+- Entity "Music Establish (ERL)" triggers bank/account cascade using updated helpers.
+- If listBanks() empty or throws, inline message: `Bank directory unavailable or missing 'code' on bank docs`.
+- Submit writes method, entity, refNumber, timestamp, editedBy and for ERL also bankCode, accountDocId, identifier = "${bankCode}/${accountDocId}".
+
+## B) UI layout tweaks
+- Bank & Bank Account selects render side-by-side in PaymentModal (Grid container md={6}).
+- Coaching Sessions card footer: keep 3-dots (`settings-3dots`) and Service Mode (`service-mode-btn`) in footer row; baselines match and stay inside card.
+- P-prompt badge: single `pprompt-badge-card` at top-right of card view only.
+
+## C) Payment Detail — fallback cascade only when fields are empty
+- When method/entity/bankCode/accountDocId missing, render inline cascade to complete metadata once.
+- Save writes same fields as Add Payment plus timestamp & editedBy; once set, fields become read-only.
+
+## D) Tests
+- lib/erlDirectory.test.ts: banks/accounts fallback logic.
+- PaymentModal.test.tsx: ERL cascade populates and submit stores identifier & audit fields.
+- PaymentDetail.test.tsx: metadata cascade saves once then renders read-only.
+
+## Acceptance
+- Add Payment dialog shows working cascade with current ERL structure.
+- Bank and Bank Account selects side-by-side.
+- Payment Detail shows cascade only when metadata missing; after save, fields read-only.
+- 3-dots and Service Mode share baseline inside card; no sidebar drift.
+- Only one P-prompt badge rendered (top-right of card).
+- No TypeScript errors; unit/RTL tests pass.


### PR DESCRIPTION
## Summary
- adapt ERL directory reader to bankAccount structure with collection-group account lookup
- cascade bank and account selects in Add Payment with inline errors and toast
- allow Payment Detail to complete missing metadata once then render read-only
- align card footer controls and keep single prompt badge

## Testing
- `npx jest lib/erlDirectory.test.ts components/StudentDialog/PaymentModal.test.tsx components/StudentDialog/PaymentDetail.test.tsx __tests__/pages/dashboard/businesses/coaching-sessions.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a6d06cb94083238aa4ac8132aec8aa