### PR TITLE
Recreate projects database flow with Firestore selection

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -63,6 +63,13 @@ export default function SidebarLayout({ children }: { children: React.ReactNode 
               </Link>
             </MenuItem>
             <MenuItem onClick={handleBusinessClose} sx={{ p: 0 }}>
+              <Link href="/dashboard/businesses/projects-database/select" passHref style={{ textDecoration: 'none', color: 'inherit', width: '100%' }}>
+                <Button fullWidth sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1 }}>
+                  Projects (Database)
+                </Button>
+              </Link>
+            </MenuItem>
+            <MenuItem onClick={handleBusinessClose} sx={{ p: 0 }}>
               <Link href="/dashboard/businesses/coaching-sessions" passHref style={{ textDecoration: 'none', color: 'inherit', width: '100%' }}>
                 <Button fullWidth sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1 }}>
                   Coaching Sessions

--- a/components/projectdialog/ProjectsDatabaseDialog.tsx
+++ b/components/projectdialog/ProjectsDatabaseDialog.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from 'react'
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+
+import { ProjectRecord } from '../../lib/projectsDatabase'
+
+const titleSx = { fontFamily: 'Cantata One' }
+const labelSx = { fontFamily: 'Newsreader', fontWeight: 200 }
+const valueSx = { fontFamily: 'Newsreader', fontWeight: 500 }
+
+interface ProjectsDatabaseDialogProps {
+  open: boolean
+  onClose: () => void
+  project: ProjectRecord
+}
+
+const normalizeText = (value: string | null | undefined) =>
+  value && value.trim().length > 0 ? value.trim() : 'N/A'
+
+const formatAmount = (value: number | null) => {
+  if (value === null || Number.isNaN(value)) {
+    return '-'
+  }
+  return `HK$${value.toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+const formatPaid = (value: boolean | null) => {
+  if (value === null) {
+    return 'N/A'
+  }
+  return value ? 'Paid' : 'Unpaid'
+}
+
+const formatPaidOn = (paid: boolean | null, date: string | null) => {
+  if (!paid) {
+    return '-'
+  }
+  return date && date.trim().length > 0 ? date : '-'
+}
+
+const formatInvoice = (invoice: string | null, invoiceUrl: string | null): ReactNode => {
+  if (invoiceUrl) {
+    const label = invoice && invoice.trim().length > 0 ? invoice : invoiceUrl
+    return (
+      <Typography
+        sx={valueSx}
+        component="a"
+        href={invoiceUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {label}
+      </Typography>
+    )
+  }
+
+  return normalizeText(invoice)
+}
+
+interface FieldProps {
+  label: string
+  value: ReactNode
+}
+
+const Field = ({ label, value }: FieldProps) => (
+  <Box sx={{ mb: 2 }}>
+    <Typography sx={labelSx}>{label}:</Typography>
+    {typeof value === 'string' ? <Typography sx={valueSx}>{value}</Typography> : value}
+  </Box>
+)
+
+export default function ProjectsDatabaseDialog({
+  open,
+  onClose,
+  project,
+}: ProjectsDatabaseDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={titleSx}>{project.projectTitle || 'Project Details'}</DialogTitle>
+      <DialogContent dividers>
+        <Field label="Project Number" value={normalizeText(project.projectNumber)} />
+        <Field label="Client Company" value={normalizeText(project.clientCompany)} />
+        <Field label="Subsidiary" value={normalizeText(project.subsidiary)} />
+        <Field label="Project Nature" value={normalizeText(project.projectNature)} />
+        <Field label="Presenter / Work Type" value={normalizeText(project.presenterWorkType)} />
+        <Field label="Project Date" value={project.projectDateDisplay ?? '-'} />
+        <Field label="Amount" value={formatAmount(project.amount)} />
+        <Field label="Paid Status" value={formatPaid(project.paid)} />
+        <Field label="Paid On" value={formatPaidOn(project.paid, project.onDateDisplay)} />
+        <Field label="Paid To" value={normalizeText(project.paidTo)} />
+        <Field label="Invoice Number" value={normalizeText(project.invoice)} />
+        <Field
+          label="Invoice"
+          value={formatInvoice(project.invoice, project.invoiceUrl)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -17,13 +17,19 @@ Object.entries(firebaseConfig).forEach(([k, v]) => {
   console.log(`   ${k}: ${v}`)
 })
 
-const databaseId = 'mel-sessions'
-console.log('📚 Firestore database ID:', databaseId)
+const DEFAULT_DATABASE_ID = 'mel-sessions'
+const PROJECTS_DATABASE_ID = 'epl-projects'
+
+console.log('📚 Firestore database ID:', DEFAULT_DATABASE_ID)
+console.log('📚 Firestore projects database ID:', PROJECTS_DATABASE_ID)
 
 export const app = !getApps().length
   ? initializeApp(firebaseConfig)
   : getApp()
-export const db = getFirestore(app, databaseId)
+export const db = getFirestore(app, DEFAULT_DATABASE_ID)
+export const projectsDb = getFirestore(app, PROJECTS_DATABASE_ID)
+export const PROJECTS_FIRESTORE_DATABASE_ID = PROJECTS_DATABASE_ID
+export const getFirestoreForDatabase = (databaseId: string) => getFirestore(app, databaseId)
 // after you create/export `db`...
 if (typeof window !== 'undefined') {
   // @ts-expect-error attach for debugging

--- a/lib/projectsDatabase.ts
+++ b/lib/projectsDatabase.ts
@@ -1,0 +1,226 @@
+// lib/projectsDatabase.ts
+
+import { collection, getDocs, Timestamp } from 'firebase/firestore'
+
+import { projectsDb, PROJECTS_FIRESTORE_DATABASE_ID } from './firebase'
+
+const YEAR_ID_PATTERN = /^\d{4}$/
+const FALLBACK_YEAR_IDS = ['2025', '2024', '2023', '2022', '2021']
+
+interface ListCollectionIdsResponse {
+  collectionIds?: string[]
+  error?: { message?: string }
+}
+
+export interface ProjectRecord {
+  id: string
+  year: string
+  amount: number | null
+  agent: string | null
+  clientCompany: string | null
+  invoiceCompany: string | null
+  invoice: string | null
+  onDateDisplay: string | null
+  onDateIso: string | null
+  paid: boolean | null
+  paidTo: string | null
+  presenterWorkType: string | null
+  projectDateDisplay: string | null
+  projectDateIso: string | null
+  projectNature: string | null
+  projectNumber: string
+  projectTitle: string | null
+  subsidiary: string | null
+  invoiceUrl: string | null
+}
+
+export interface ProjectsDatabaseResult {
+  projects: ProjectRecord[]
+  years: string[]
+}
+
+const toTimestamp = (value: unknown): Timestamp | null => {
+  if (value instanceof Timestamp) {
+    return value
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    'seconds' in value &&
+    'nanoseconds' in value &&
+    typeof (value as any).seconds === 'number' &&
+    typeof (value as any).nanoseconds === 'number'
+  ) {
+    return new Timestamp((value as any).seconds, (value as any).nanoseconds)
+  }
+  return null
+}
+
+const toDate = (value: unknown): Date | null => {
+  const ts = toTimestamp(value)
+  if (ts) {
+    const date = ts.toDate()
+    return isNaN(date.getTime()) ? null : date
+  }
+  if (typeof value === 'string' || value instanceof String) {
+    const parsed = new Date(value as string)
+    return isNaN(parsed.getTime()) ? null : parsed
+  }
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value
+  }
+  return null
+}
+
+const formatDisplayDate = (value: unknown): string | null => {
+  const date = toDate(value)
+  if (!date) return null
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  })
+}
+
+const toIsoDate = (value: unknown): string | null => {
+  const date = toDate(value)
+  if (!date) return null
+  return date.toISOString()
+}
+
+const toStringValue = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value.trim() || null
+  }
+  if (value instanceof String) {
+    const trimmed = value.toString().trim()
+    return trimmed || null
+  }
+  return null
+}
+
+const toNumberValue = (value: unknown): number | null => {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return value
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+const toBooleanValue = (value: unknown): boolean | null => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+  return null
+}
+
+const uniqueSortedYears = (values: Iterable<string>) =>
+  Array.from(new Set(values)).sort((a, b) =>
+    b.localeCompare(a, undefined, { numeric: true })
+  )
+
+const listYearCollections = async (): Promise<string[]> => {
+  const apiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY
+  const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID
+
+  if (!apiKey || !projectId) {
+    console.warn('[projectsDatabase] Missing Firebase configuration, falling back to defaults')
+    return [...FALLBACK_YEAR_IDS]
+  }
+
+  const url = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/${PROJECTS_FIRESTORE_DATABASE_ID}/documents:listCollectionIds?key=${apiKey}`
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        parent: `projects/${projectId}/databases/${PROJECTS_FIRESTORE_DATABASE_ID}/documents`,
+        pageSize: 200,
+      }),
+    })
+
+    if (!response.ok) {
+      console.warn('[projectsDatabase] Failed to list collection IDs:', response.status, response.statusText)
+      return [...FALLBACK_YEAR_IDS]
+    }
+
+    const json = (await response.json()) as ListCollectionIdsResponse
+    if (json.error) {
+      console.warn('[projectsDatabase] Firestore responded with error:', json.error.message)
+      return [...FALLBACK_YEAR_IDS]
+    }
+
+    const ids = json.collectionIds?.filter((id) => YEAR_ID_PATTERN.test(id)) ?? []
+    if (ids.length === 0) {
+      console.warn('[projectsDatabase] No year collections found, falling back to defaults')
+      return [...FALLBACK_YEAR_IDS]
+    }
+    return uniqueSortedYears(ids)
+  } catch (err) {
+    console.warn('[projectsDatabase] listYearCollections failed:', err)
+    return [...FALLBACK_YEAR_IDS]
+  }
+}
+
+export const fetchProjectsFromDatabase = async (): Promise<ProjectsDatabaseResult> => {
+  const yearIds = await listYearCollections()
+  const projects: ProjectRecord[] = []
+  const yearsWithData = new Set<string>()
+
+  await Promise.all(
+    yearIds.map(async (year) => {
+      const snapshot = await getDocs(collection(projectsDb, year))
+      snapshot.forEach((doc) => {
+        const data = doc.data() as Record<string, unknown>
+        const projectNumber = toStringValue(data.projectNumber) ?? doc.id
+
+        const amount = toNumberValue(data.amount)
+        const projectDateIso = toIsoDate(data.projectDate)
+        const projectDateDisplay = formatDisplayDate(data.projectDate)
+        const onDateIso = toIsoDate(data.onDate)
+        const onDateDisplay = formatDisplayDate(data.onDate)
+
+        projects.push({
+          id: doc.id,
+          year,
+          amount,
+          agent: toStringValue(data.agent),
+          clientCompany: toStringValue(data.clientCompany),
+          invoiceCompany: toStringValue(data.invoiceCompany) ?? toStringValue(data.clientCompany),
+          invoice: toStringValue(data.invoice),
+          onDateDisplay,
+          onDateIso,
+          paid: toBooleanValue(data.paid),
+          paidTo: toStringValue(data.paidTo),
+          presenterWorkType: toStringValue(data.presenterWorkType),
+          projectDateDisplay,
+          projectDateIso,
+          projectNature: toStringValue(data.projectNature),
+          projectNumber,
+          projectTitle: toStringValue(data.projectTitle),
+          subsidiary: toStringValue(data.subsidiary),
+          invoiceUrl: toStringValue(data.invoiceUrl),
+        })
+
+        yearsWithData.add(year)
+      })
+    })
+  )
+
+  projects.sort((a, b) => {
+    if (a.year !== b.year) {
+      return b.year.localeCompare(a.year, undefined, { numeric: true })
+    }
+    return a.projectNumber.localeCompare(b.projectNumber, undefined, { numeric: true })
+  })
+
+  return {
+    projects,
+    years: uniqueSortedYears(yearsWithData),
+  }
+}
+

--- a/pages/dashboard/businesses/index.tsx
+++ b/pages/dashboard/businesses/index.tsx
@@ -3,32 +3,21 @@
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import SidebarLayout from '../../../components/SidebarLayout';
-import { initializeApis } from '../../../lib/googleApi';
-import { listProjectOverviewFiles } from '../../../lib/projectOverview';
 import { useRouter } from 'next/router';
 import { Box, Typography, List, ListItemButton, ListItemText, Button } from '@mui/material';
-import { drive_v3 } from 'googleapis';
 
-interface BusinessFile {
-  companyIdentifier: string;
-  fullCompanyName: string;
-  file: drive_v3.Schema$File;
+interface BusinessLink {
+  title: string;
+  description: string;
+  href: string;
 }
 
 interface BusinessesPageProps {
-  projectsByCategory: Record<string, BusinessFile[]>;
+  businessLinks: BusinessLink[];
 }
 
-export default function BusinessesPage({ projectsByCategory }: BusinessesPageProps) {
+export default function BusinessesPage({ businessLinks }: BusinessesPageProps) {
   const router = useRouter();
-
-  // Flatten the grouped projects into a single array.
-  // (The original code grouped them by subsidiary code; now we sort them alphabetically by fullCompanyName.)
-  const files: BusinessFile[] = [];
-  for (const key in projectsByCategory) {
-    projectsByCategory[key].forEach((file) => files.push(file));
-  }
-  files.sort((a, b) => a.fullCompanyName.localeCompare(b.fullCompanyName));
 
   return (
     <SidebarLayout>
@@ -43,12 +32,9 @@ export default function BusinessesPage({ projectsByCategory }: BusinessesPagePro
         Select a project overview file:
       </Typography>
       <List>
-        {files.map((file) => (
-          <ListItemButton
-            key={file.file.id}
-            onClick={() => router.push(`/dashboard/businesses/${file.file.id}`)}
-          >
-            <ListItemText primary={file.fullCompanyName} secondary={file.file.name} />
+        {businessLinks.map((link) => (
+          <ListItemButton key={link.href} onClick={() => router.push(link.href)}>
+            <ListItemText primary={link.title} secondary={link.description} />
           </ListItemButton>
         ))}
       </List>
@@ -61,12 +47,15 @@ export const getServerSideProps: GetServerSideProps<BusinessesPageProps> = async
   if (!session?.accessToken) {
     return { redirect: { destination: '/api/auth/signin', permanent: false } };
   }
-  const { drive } = initializeApis('user', { accessToken: session.accessToken as string });
-  // Get the grouped project files using your existing sorting utility
-  const projectsByCategory = await listProjectOverviewFiles(drive, []);
   return {
     props: {
-      projectsByCategory,
+      businessLinks: [
+        {
+          title: 'Establish Productions Limited',
+          description: 'Projects (Database)',
+          href: '/dashboard/businesses/projects-database/select',
+        },
+      ],
     },
   };
 };

--- a/pages/dashboard/businesses/projects-database/[groupId].tsx
+++ b/pages/dashboard/businesses/projects-database/[groupId].tsx
@@ -1,0 +1,470 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useState } from 'react'
+
+import SidebarLayout from '../../../../components/SidebarLayout'
+import ProjectsDatabaseDialog from '../../../../components/projectdialog/ProjectsDatabaseDialog'
+import { fetchProjectsFromDatabase, ProjectRecord } from '../../../../lib/projectsDatabase'
+
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material'
+import type { SelectChangeEvent } from '@mui/material/Select'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+
+type SortMethod = 'year' | 'company'
+
+interface ProjectGroupSummary {
+  year: string
+  subsidiary: string
+  groupId: string
+  displayName: string
+  projectCount: number
+}
+
+type GroupMap = Record<string, ProjectGroupSummary[]>
+
+interface DetailSelection {
+  year: string
+  subsidiary: string
+  displayName: string
+}
+
+interface ProjectsDatabasePageProps {
+  mode: 'select' | 'detail'
+  years: string[]
+  companies: string[]
+  groupsByYear: GroupMap
+  groupsByCompany: GroupMap
+  projects: ProjectRecord[]
+  selection?: DetailSelection
+  error?: string
+}
+
+const headingSx = { fontFamily: 'Cantata One' }
+const valueSx = { fontFamily: 'Newsreader', fontWeight: 500 }
+
+const encodeGroupId = (year: string, subsidiary: string) =>
+  `${encodeURIComponent(year)}---${encodeURIComponent(subsidiary)}`
+
+const decodeGroupId = (value: string): { year: string; subsidiary: string } | null => {
+  const [yearPart, subsidiaryPart] = value.split('---')
+  if (!yearPart || !subsidiaryPart) {
+    return null
+  }
+
+  try {
+    return {
+      year: decodeURIComponent(yearPart),
+      subsidiary: decodeURIComponent(subsidiaryPart),
+    }
+  } catch (err) {
+    console.warn('[projects-database] Failed to decode group id', err)
+    return null
+  }
+}
+
+const formatAmount = (value: number | null) => {
+  if (value === null || Number.isNaN(value)) {
+    return '-'
+  }
+  return `HK$${value.toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+const paidStatus = (value: boolean | null) => {
+  if (value === null) {
+    return 'N/A'
+  }
+  return value ? 'Paid' : 'Unpaid'
+}
+
+export default function ProjectsDatabasePage({
+  mode,
+  years,
+  companies,
+  groupsByYear,
+  groupsByCompany,
+  projects,
+  selection,
+  error,
+}: ProjectsDatabasePageProps) {
+  const router = useRouter()
+
+  const [sortMethod, setSortMethod] = useState<SortMethod>('year')
+  const [selectedYear, setSelectedYear] = useState<string>(years[0] ?? '')
+  const [selectedCompany, setSelectedCompany] = useState<string>(companies[0] ?? '')
+  const [dialogProject, setDialogProject] = useState<ProjectRecord | null>(null)
+
+  useEffect(() => {
+    if (mode === 'detail' && selection) {
+      setSortMethod('year')
+      setSelectedYear(selection.year)
+      setSelectedCompany(selection.subsidiary)
+    }
+  }, [mode, selection])
+
+  useEffect(() => {
+    if (sortMethod === 'year') {
+      if (!selectedYear && years.length > 0) {
+        setSelectedYear(years[0])
+      }
+    } else if (sortMethod === 'company') {
+      if (!selectedCompany && companies.length > 0) {
+        setSelectedCompany(companies[0])
+      }
+    }
+  }, [sortMethod, years, companies, selectedYear, selectedCompany])
+
+  const handleYearChange = (event: SelectChangeEvent<string>) => {
+    setSelectedYear(event.target.value)
+  }
+
+  const handleCompanyChange = (event: SelectChangeEvent<string>) => {
+    setSelectedCompany(event.target.value)
+  }
+
+  const groupsToDisplay = useMemo(() => {
+    if (sortMethod === 'year') {
+      return selectedYear ? groupsByYear[selectedYear] ?? [] : []
+    }
+    return selectedCompany ? groupsByCompany[selectedCompany] ?? [] : []
+  }, [sortMethod, selectedYear, selectedCompany, groupsByYear, groupsByCompany])
+
+  const handleNavigate = (group: ProjectGroupSummary) => {
+    router.push(`/dashboard/businesses/projects-database/${group.groupId}`)
+  }
+
+  if (mode === 'select') {
+    return (
+      <SidebarLayout>
+        <Box sx={{ p: 2 }}>
+          <Typography variant="h4" sx={headingSx} gutterBottom>
+            Projects (Database)
+          </Typography>
+          <Typography variant="h6" sx={headingSx} gutterBottom>
+            Establish Productions Limited
+          </Typography>
+          {error && (
+            <Typography color="error" sx={{ mb: 2 }}>
+              {error}
+            </Typography>
+          )}
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 2,
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              mb: 3,
+            }}
+          >
+            <ToggleButtonGroup
+              value={sortMethod}
+              exclusive
+              onChange={(_, value: SortMethod | null) => {
+                if (value) {
+                  setSortMethod(value)
+                }
+              }}
+              size="small"
+            >
+              <ToggleButton value="year">By Year</ToggleButton>
+              <ToggleButton value="company">By Company</ToggleButton>
+            </ToggleButtonGroup>
+            {sortMethod === 'year' && years.length > 0 && (
+              <FormControl sx={{ minWidth: 140 }}>
+                <InputLabel>Year</InputLabel>
+                <Select value={selectedYear} label="Year" onChange={handleYearChange}>
+                  {years.map((year) => (
+                    <MenuItem key={year} value={year}>
+                      {year}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+            {sortMethod === 'company' && companies.length > 0 && (
+              <FormControl sx={{ minWidth: 220 }}>
+                <InputLabel>Company</InputLabel>
+                <Select value={selectedCompany} label="Company" onChange={handleCompanyChange}>
+                  {companies.map((company) => (
+                    <MenuItem key={company} value={company}>
+                      {company}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          </Box>
+          {groupsToDisplay.length === 0 ? (
+            <Typography>No project collections available.</Typography>
+          ) : (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+              {groupsToDisplay.map((group) => (
+                <Card
+                  key={group.groupId}
+                  sx={{ cursor: 'pointer', width: 260 }}
+                  onClick={() => handleNavigate(group)}
+                >
+                  <CardContent>
+                    <Typography variant="h6" sx={headingSx} gutterBottom>
+                      {sortMethod === 'year' ? group.displayName : group.year}
+                    </Typography>
+                    <Typography sx={valueSx}>
+                      {sortMethod === 'year'
+                        ? `${group.projectCount} project${group.projectCount === 1 ? '' : 's'}`
+                        : group.displayName}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </SidebarLayout>
+    )
+  }
+
+  const handleBack = () => {
+    router.push('/dashboard/businesses/projects-database/select')
+  }
+
+  const listLabel = selection
+    ? `${selection.displayName} — ${selection.year}`
+    : 'Projects'
+
+  return (
+    <SidebarLayout>
+      <Box sx={{ p: 2 }}>
+        <Box
+          sx={{
+            mb: 2,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <IconButton onClick={handleBack}>
+            <ArrowBackIcon />
+          </IconButton>
+          <Box sx={{ textAlign: 'center' }}>
+            <Typography variant="h5" sx={headingSx}>
+              {listLabel}
+            </Typography>
+            <Typography sx={valueSx}>Project Overview</Typography>
+          </Box>
+          <Button variant="contained" onClick={() => router.push('/dashboard/businesses/new')}>
+            New Project
+          </Button>
+        </Box>
+        {error && (
+          <Typography color="error" sx={{ mb: 2 }}>
+            {error}
+          </Typography>
+        )}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={headingSx} gutterBottom>
+              Project List
+            </Typography>
+            {projects.length === 0 ? (
+              <Typography>No project records available.</Typography>
+            ) : (
+              <Box component="ul" sx={{ m: 0, p: 0, listStyle: 'none' }}>
+                {projects.map((project) => {
+                  const secondaryParts = [formatAmount(project.amount), paidStatus(project.paid)]
+                  if (project.paid && project.onDateDisplay) {
+                    secondaryParts.push(project.onDateDisplay)
+                  }
+
+                  return (
+                    <Box
+                      key={`${project.year}-${project.projectNumber}`}
+                      component="li"
+                      sx={{
+                        cursor: 'pointer',
+                        borderBottom: '1px solid rgba(0,0,0,0.12)',
+                        py: 1.5,
+                      }}
+                      onClick={() => setDialogProject(project)}
+                    >
+                      <Typography sx={valueSx}>
+                        {`${project.projectNumber} — ${project.projectTitle ?? 'Untitled Project'}`}
+                      </Typography>
+                      <Typography sx={{ ...valueSx, fontSize: 14 }}>
+                        {secondaryParts.join(' | ')}
+                      </Typography>
+                    </Box>
+                  )
+                })}
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+      </Box>
+      {dialogProject && (
+        <ProjectsDatabaseDialog
+          open={Boolean(dialogProject)}
+          onClose={() => setDialogProject(null)}
+          project={dialogProject}
+        />
+      )}
+    </SidebarLayout>
+  )
+}
+
+const normalizeSubsidiary = (value: string | null | undefined) =>
+  value && value.trim().length > 0 ? value.trim() : 'Establish Productions Limited'
+
+const sortCompanies = (values: Iterable<string>) =>
+  Array.from(new Set(values)).sort((a, b) => a.localeCompare(b))
+
+export const getServerSideProps: GetServerSideProps<ProjectsDatabasePageProps> = async (
+  ctx
+) => {
+  const session = await getSession(ctx)
+  if (!session?.accessToken) {
+    return { redirect: { destination: '/api/auth/signin/google', permanent: false } }
+  }
+
+  try {
+    const { projects, years } = await fetchProjectsFromDatabase()
+
+    const groupLookup = new Map<string, ProjectGroupSummary>()
+    const groupsByYear: GroupMap = {}
+    const groupsByCompany: GroupMap = {}
+
+    projects.forEach((project) => {
+      const year = project.year
+      const subsidiary = normalizeSubsidiary(project.subsidiary)
+      const key = `${year}|||${subsidiary}`
+      let summary = groupLookup.get(key)
+      if (!summary) {
+        summary = {
+          year,
+          subsidiary,
+          displayName: subsidiary,
+          projectCount: 0,
+          groupId: encodeGroupId(year, subsidiary),
+        }
+        groupLookup.set(key, summary)
+        if (!groupsByYear[year]) {
+          groupsByYear[year] = []
+        }
+        groupsByYear[year].push(summary)
+        if (!groupsByCompany[subsidiary]) {
+          groupsByCompany[subsidiary] = []
+        }
+        groupsByCompany[subsidiary].push(summary)
+      }
+      summary.projectCount += 1
+    })
+
+    Object.values(groupsByYear).forEach((list) =>
+      list.sort((a, b) => a.displayName.localeCompare(b.displayName))
+    )
+    Object.values(groupsByCompany).forEach((list) =>
+      list.sort((a, b) => b.year.localeCompare(a.year, undefined, { numeric: true }))
+    )
+
+    const companies = sortCompanies(Object.keys(groupsByCompany))
+
+    const groupParam = ctx.params?.groupId as string | undefined
+
+    if (!groupParam || groupParam === 'select') {
+      return {
+        props: {
+          mode: 'select',
+          years,
+          companies,
+          groupsByYear,
+          groupsByCompany,
+          projects: [],
+        },
+      }
+    }
+
+    const decoded = decodeGroupId(groupParam)
+    if (!decoded) {
+      return {
+        props: {
+          mode: 'select',
+          years,
+          companies,
+          groupsByYear,
+          groupsByCompany,
+          projects: [],
+          error: 'Invalid project selection, please choose again.',
+        },
+      }
+    }
+
+    const normalizedSubsidiaryValue = normalizeSubsidiary(decoded.subsidiary)
+    const groupKey = `${decoded.year}|||${normalizedSubsidiaryValue}`
+    const summary = groupLookup.get(groupKey)
+    if (!summary) {
+      return {
+        props: {
+          mode: 'select',
+          years,
+          companies,
+          groupsByYear,
+          groupsByCompany,
+          projects: [],
+          error: 'Project collection not found, please choose again.',
+        },
+      }
+    }
+
+    const matchingProjects = projects.filter(
+      (project) =>
+        project.year === decoded.year &&
+        normalizeSubsidiary(project.subsidiary) === normalizedSubsidiaryValue
+    )
+
+    return {
+      props: {
+        mode: 'detail',
+        years,
+        companies,
+        groupsByYear,
+        groupsByCompany,
+        projects: matchingProjects,
+        selection: {
+          year: decoded.year,
+          subsidiary: normalizedSubsidiaryValue,
+          displayName: summary.displayName,
+        },
+      },
+    }
+  } catch (err) {
+    console.error('[projects-database] Failed to load projects', err)
+    return {
+      props: {
+        mode: 'select',
+        years: [],
+        companies: [],
+        groupsByYear: {},
+        groupsByCompany: {},
+        projects: [],
+        error: err instanceof Error ? err.message : 'Error retrieving project records',
+      },
+    }
+  }
+}
+

--- a/pages/dashboard/businesses/projects-database/index.tsx
+++ b/pages/dashboard/businesses/projects-database/index.tsx
@@ -1,0 +1,14 @@
+import { GetServerSideProps } from 'next'
+
+const ProjectsDatabaseIndex = () => null
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: '/dashboard/businesses/projects-database/select',
+      permanent: false,
+    },
+  }
+}
+
+export default ProjectsDatabaseIndex


### PR DESCRIPTION
## Summary
- rebuild the Projects (Database) select/detail flow so the Firestore collections mirror the original Projects page experience
- add a dedicated project dialog for Firestore records with typography and field handling that matches the existing conventions
- extend the Firestore project loader to capture agent, invoice company, and invoice URL details for the modal view

## Testing
- npm run lint *(fails: existing violations in Cypress and Jest configuration files)*

------
https://chatgpt.com/codex/tasks/task_e_68d50e59bc848323b956cf669f6ea883