### PR TITLE
Improve Firebase sign-in diagnostics

### DIFF
--- a/lib/firebaseAdmin.ts
+++ b/lib/firebaseAdmin.ts
@@ -1,19 +1,44 @@
 import admin from 'firebase-admin'
 
+function stripWrappingQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0]
+    const last = value[value.length - 1]
+    if (first === last && (first === '"' || first === "'")) {
+      return value.slice(1, -1)
+    }
+  }
+  return value
+}
+
 const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID
 const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL
-const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY?.replace(/\\n/g, '\n')
+const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY
+  ? stripWrappingQuotes(process.env.FIREBASE_ADMIN_PRIVATE_KEY).replace(/\\n/g, '\n')
+  : undefined
+
+const hasServiceAccountCredentials = Boolean(projectId && clientEmail && privateKey)
+
+export const firebaseAdminConfigStatus = {
+  hasProjectId: Boolean(projectId),
+  hasClientEmail: Boolean(clientEmail),
+  hasPrivateKey: Boolean(privateKey),
+  credentialSource: hasServiceAccountCredentials ? 'service-account' : 'default',
+} as const
 
 if (!admin.apps.length) {
-  if (projectId && clientEmail && privateKey) {
+  if (hasServiceAccountCredentials) {
     admin.initializeApp({
       credential: admin.credential.cert({
-        projectId,
-        clientEmail,
-        privateKey,
+        projectId: projectId!,
+        clientEmail: clientEmail!,
+        privateKey: privateKey!,
       }),
     })
   } else {
+    console.warn(
+      '[auth] Firebase Admin initialized without FIREBASE_ADMIN service-account credentials. Token verification will fail until they are configured.'
+    )
     admin.initializeApp()
   }
 }

--- a/pages/api/auth/firebase-diagnostics.ts
+++ b/pages/api/auth/firebase-diagnostics.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import {
+  firebaseAdminAuth,
+  firebaseAdminConfigStatus,
+} from '../../../lib/firebaseAdmin'
+
+type DiagnosticsSuccessResponse = {
+  ok: true
+  uid: string
+  projectId: string | null
+}
+
+type DiagnosticsFailureResponse = {
+  ok: false
+  message: string
+  code?: string
+  config: typeof firebaseAdminConfigStatus
+}
+
+type DiagnosticsResponse = DiagnosticsSuccessResponse | DiagnosticsFailureResponse
+
+function buildMissingEnvMessage(): string | null {
+  const missing: string[] = []
+  if (!firebaseAdminConfigStatus.hasProjectId) {
+    missing.push('FIREBASE_ADMIN_PROJECT_ID')
+  }
+  if (!firebaseAdminConfigStatus.hasClientEmail) {
+    missing.push('FIREBASE_ADMIN_CLIENT_EMAIL')
+  }
+  if (!firebaseAdminConfigStatus.hasPrivateKey) {
+    missing.push('FIREBASE_ADMIN_PRIVATE_KEY')
+  }
+
+  if (!missing.length) {
+    return null
+  }
+
+  return `Missing environment variables: ${missing.join(', ')}`
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<DiagnosticsResponse>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    res.status(405).json({
+      ok: false,
+      message: 'Method Not Allowed',
+      config: firebaseAdminConfigStatus,
+    })
+    return
+  }
+
+  const idToken = typeof req.body === 'object' ? (req.body as any)?.idToken : undefined
+
+  if (typeof idToken !== 'string' || !idToken.trim()) {
+    res.status(400).json({
+      ok: false,
+      message: 'Missing Firebase ID token',
+      config: firebaseAdminConfigStatus,
+    })
+    return
+  }
+
+  if (firebaseAdminConfigStatus.credentialSource !== 'service-account') {
+    const missingMessage = buildMissingEnvMessage()
+    res.status(200).json({
+      ok: false,
+      message:
+        missingMessage ??
+        'Firebase Admin was initialized without service-account credentials. Token verification cannot proceed.',
+      config: firebaseAdminConfigStatus,
+    })
+    return
+  }
+
+  try {
+    const decoded = await firebaseAdminAuth.verifyIdToken(idToken)
+    res.status(200).json({
+      ok: true,
+      uid: decoded.uid,
+      projectId: (decoded as any)?.aud ?? null,
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Firebase Admin could not verify the provided token.'
+    const code = typeof error === 'object' && error && 'code' in error ? String((error as any).code) : undefined
+
+    res.status(200).json({
+      ok: false,
+      message,
+      code,
+      config: firebaseAdminConfigStatus,
+    })
+  }
+}

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import {
@@ -20,6 +20,20 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
+
+type FirebaseDiagnosticsResponse =
+  | { ok: true; uid: string; projectId: string | null }
+  | {
+      ok: false
+      message: string
+      code?: string
+      config: {
+        hasProjectId: boolean
+        hasClientEmail: boolean
+        hasPrivateKey: boolean
+        credentialSource: 'service-account' | 'default'
+      }
+    }
 
 const buttonStyles = {
   height: 48,
@@ -50,6 +64,58 @@ export default function SignInPage() {
     return provider
   }, [])
 
+  const diagnoseCredentialFailure = useCallback(async (idToken: string) => {
+    try {
+      const response = await fetch('/api/auth/firebase-diagnostics', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ idToken }),
+      })
+
+      if (!response.ok) {
+        return null
+      }
+
+      const data = (await response.json()) as FirebaseDiagnosticsResponse
+
+      if (data.ok) {
+        return 'Firebase Admin accepted the token when retried directly, but NextAuth still rejected the exchange. Check the server logs for additional context.'
+      }
+
+      const messageParts: string[] = []
+
+      if (data.message) {
+        messageParts.push(data.message)
+      }
+
+      if (data.code) {
+        messageParts.push(`(code: ${data.code})`)
+      }
+
+      if (data.config) {
+        if (data.config.credentialSource !== 'service-account') {
+          messageParts.push(
+            'Firebase Admin is running without service-account credentials. Set FIREBASE_ADMIN_PROJECT_ID, FIREBASE_ADMIN_CLIENT_EMAIL, and FIREBASE_ADMIN_PRIVATE_KEY.'
+          )
+        } else {
+          const missing: string[] = []
+          if (!data.config.hasProjectId) missing.push('FIREBASE_ADMIN_PROJECT_ID')
+          if (!data.config.hasClientEmail) missing.push('FIREBASE_ADMIN_CLIENT_EMAIL')
+          if (!data.config.hasPrivateKey) missing.push('FIREBASE_ADMIN_PRIVATE_KEY')
+
+          if (missing.length) {
+            messageParts.push(`Missing environment variables: ${missing.join(', ')}`)
+          }
+        }
+      }
+
+      return messageParts.join(' ')
+    } catch (diagnosticError) {
+      console.error('[auth] Failed to run Firebase diagnostics', diagnosticError)
+      return null
+    }
+  }, [])
+
   const completeNextAuth = async (params: {
     idToken: string
     accessToken?: string | null
@@ -62,11 +128,24 @@ export default function SignInPage() {
       redirect: false,
     })
 
-    if (response?.error) {
-      throw new Error(response.error)
+    if (!response) {
+      throw new Error('No response from authentication service')
     }
 
-    await router.replace('/')
+    if (response.error) {
+      console.error('[auth] NextAuth credential exchange failed', response)
+      let mappedError = response.error
+
+      if (response.error === 'CredentialsSignin') {
+        mappedError =
+          (await diagnoseCredentialFailure(params.idToken)) ??
+          'Google sign-in was rejected by the server. Please verify the Firebase Admin environment variables.'
+      }
+
+      throw new Error(mappedError)
+    }
+
+    await router.replace(response.url ?? '/')
   }
 
   const handleGoogleSignIn = async () => {


### PR DESCRIPTION
## Summary
- surface Firebase Admin verification failures with descriptive errors in the NextAuth credentials provider
- map NextAuth credential failures to a clearer frontend message when Google sign-in succeeds but the server rejects the token
- add Firebase Admin configuration diagnostics so missing service-account environment variables surface immediately and can be queried from the sign-in flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1754691d4832387c4c77224bc3f19