### PR TITLE
Guard Firebase config logging in development

### DIFF
--- a/__tests__/pages/auth/signin.test.tsx
+++ b/__tests__/pages/auth/signin.test.tsx
@@ -1,0 +1,134 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+  }),
+}))
+
+const mockSignIn = jest.fn()
+
+jest.mock('next-auth/react', () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+  useSession: () => ({ status: 'unauthenticated' }),
+}))
+
+const mockCredentialFromResult = jest.fn()
+const mockSignInWithPopup = jest.fn()
+
+jest.mock('firebase/auth', () => ({
+  GoogleAuthProvider: Object.assign(
+    function GoogleAuthProvider(this: any) {
+      this.addScope = jest.fn()
+      this.setCustomParameters = jest.fn()
+    },
+    {
+      credentialFromResult: (...args: unknown[]) => mockCredentialFromResult(...args),
+    }
+  ),
+  signInWithPopup: (...args: unknown[]) => mockSignInWithPopup(...args),
+  signInWithEmailAndPassword: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+}))
+
+jest.mock('../../../lib/firebaseClientAuth', () => ({
+  auth: {},
+}))
+
+describe('SignInPage Google diagnostics', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    mockSignIn.mockReset()
+    mockSignInWithPopup.mockReset()
+    mockCredentialFromResult.mockReset()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (global as Record<string, unknown>).fetch
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('shows diagnostic message when credentials sign-in fails', async () => {
+    const diagnosticMessage = 'Detailed Firebase diagnostics message'
+
+    mockSignInWithPopup.mockResolvedValue({
+      user: {
+        getIdToken: jest.fn().mockResolvedValue('id-token'),
+        refreshToken: 'refresh-token',
+      },
+    })
+
+    mockCredentialFromResult.mockReturnValue({ accessToken: 'access-token' })
+
+    mockSignIn.mockResolvedValue({
+      error: 'CredentialsSignin',
+      ok: false,
+      status: 401,
+    })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: false, message: diagnosticMessage }),
+    }) as unknown as typeof fetch
+
+    const { default: SignInPage } = await import('../../../pages/auth/signin')
+
+    render(<SignInPage />)
+
+    const googleButton = screen.getByRole('button', { name: /continue with google/i })
+    fireEvent.click(googleButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(diagnosticMessage)
+    })
+  })
+
+  it('falls back to NextAuth error when diagnostics return nothing', async () => {
+    mockSignInWithPopup.mockResolvedValue({
+      user: {
+        getIdToken: jest.fn().mockResolvedValue('id-token'),
+        refreshToken: 'refresh-token',
+      },
+    })
+
+    mockCredentialFromResult.mockReturnValue({ accessToken: 'access-token' })
+
+    const nextAuthError = 'Server rejected credentials'
+
+    mockSignIn.mockResolvedValue({
+      error: nextAuthError,
+      ok: false,
+      status: 401,
+    })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: false,
+        message: '',
+        config: {
+          hasProjectId: true,
+          hasClientEmail: true,
+          hasPrivateKey: true,
+          credentialSource: 'service-account',
+        },
+      }),
+    }) as unknown as typeof fetch
+
+    const { default: SignInPage } = await import('../../../pages/auth/signin')
+
+    render(<SignInPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(nextAuthError)
+    })
+  })
+})

--- a/__tests__/pages/dashboard/new-ui/client-accounts.test.tsx
+++ b/__tests__/pages/dashboard/new-ui/client-accounts.test.tsx
@@ -1,0 +1,39 @@
+import type { GetServerSidePropsContext } from 'next'
+import { getSession } from 'next-auth/react'
+
+import { getServerSideProps } from '../../../../pages/dashboard/new-ui/client-accounts'
+
+jest.mock('next-auth/react', () => ({
+  getSession: jest.fn(),
+}))
+
+describe('Client Accounts (Refine preview) getServerSideProps', () => {
+  const mockContext = {} as GetServerSidePropsContext
+  const getSessionMock = getSession as jest.Mock
+
+  beforeEach(() => {
+    getSessionMock.mockReset()
+  })
+
+  it('redirects to sign-in when no authenticated user is present', async () => {
+    getSessionMock.mockResolvedValue(null)
+
+    const result = await getServerSideProps(mockContext)
+
+    expect(result).toEqual({
+      redirect: { destination: '/api/auth/signin', permanent: false },
+    })
+    expect(getSessionMock).toHaveBeenCalledWith(mockContext)
+  })
+
+  it('allows access when the session only includes user information', async () => {
+    getSessionMock.mockResolvedValue({
+      user: { name: 'Ada Lovelace', email: 'ada@example.com' },
+    })
+
+    const result = await getServerSideProps(mockContext)
+
+    expect(result).toEqual({ props: {} })
+    expect(getSessionMock).toHaveBeenCalledWith(mockContext)
+  })
+})

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -9,19 +9,20 @@ const firebaseConfig = {
   projectId:            process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
   storageBucket:        process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
   messagingSenderId:    process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-  appId:                process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
+  appId:                process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
 }
-
-console.log('🔥 Firebase config:', firebaseConfig)
-Object.entries(firebaseConfig).forEach(([k, v]) => {
-  console.log(`   ${k}: ${v}`)
-})
 
 const DEFAULT_DATABASE_ID = 'mel-sessions'
 const PROJECTS_DATABASE_ID = 'epl-projects'
 
-console.log('📚 Firestore database ID:', DEFAULT_DATABASE_ID)
-console.log('📚 Firestore projects database ID:', PROJECTS_DATABASE_ID)
+if (process.env.NODE_ENV !== 'production') {
+  console.log('🔥 Firebase config:', firebaseConfig)
+  Object.entries(firebaseConfig).forEach(([k, v]) => {
+    console.log(`   ${k}: ${v}`)
+  })
+  console.log('📚 Firestore database ID:', DEFAULT_DATABASE_ID)
+  console.log('📚 Firestore projects database ID:', PROJECTS_DATABASE_ID)
+}
 
 export const app = !getApps().length
   ? initializeApp(firebaseConfig)

--- a/pages/dashboard/new-ui/client-accounts.tsx
+++ b/pages/dashboard/new-ui/client-accounts.tsx
@@ -234,7 +234,7 @@ export default function ClientAccountsPage() {
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const session = await getSession(ctx)
-  if (!session?.accessToken) {
+  if (!session?.user) {
     return {
       redirect: {
         destination: "/api/auth/signin",


### PR DESCRIPTION
## Summary
- relax the Client Accounts Refine preview guard so any authenticated session can load the page instead of bouncing back to the dashboard
- add server-side rendering coverage that locks in the new behaviour when no Google access token is present
- guard the Firebase config and database identifier debug logs so they only appear in non-production builds

## Testing
- npx jest __tests__/pages/dashboard/new-ui/client-accounts.test.tsx
- npx jest __tests__/pages/auth/signin.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e23145d4e88323931f3627c96a4770