### PR TITLE
Improve NextAuth diagnostics for credential failures

### DIFF
--- a/__tests__/pages/auth/signin.test.tsx
+++ b/__tests__/pages/auth/signin.test.tsx
@@ -1,0 +1,197 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+  }),
+}))
+
+const mockSignIn = jest.fn()
+
+jest.mock('next-auth/react', () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+  useSession: () => ({ status: 'unauthenticated' }),
+}))
+
+const mockCredentialFromResult = jest.fn()
+const mockSignInWithPopup = jest.fn()
+
+jest.mock('firebase/auth', () => ({
+  GoogleAuthProvider: Object.assign(
+    function GoogleAuthProvider(this: any) {
+      this.addScope = jest.fn()
+      this.setCustomParameters = jest.fn()
+    },
+    {
+      credentialFromResult: (...args: unknown[]) => mockCredentialFromResult(...args),
+    }
+  ),
+  signInWithPopup: (...args: unknown[]) => mockSignInWithPopup(...args),
+  signInWithEmailAndPassword: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+}))
+
+jest.mock('../../../lib/firebaseClientAuth', () => ({
+  auth: {},
+}))
+
+describe('SignInPage Google diagnostics', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    mockSignIn.mockReset()
+    mockSignInWithPopup.mockReset()
+    mockCredentialFromResult.mockReset()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (global as Record<string, unknown>).fetch
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('surfaces NextAuth diagnostics failures ahead of other messaging', async () => {
+    mockSignInWithPopup.mockResolvedValue({
+      user: {
+        getIdToken: jest.fn().mockResolvedValue('id-token'),
+        refreshToken: 'refresh-token',
+      },
+    })
+
+    mockCredentialFromResult.mockReturnValue({ accessToken: 'access-token' })
+
+    mockSignIn.mockResolvedValue({
+      error: 'CredentialsSignin',
+      ok: false,
+      status: 401,
+    })
+
+    const nextAuthDiagnosticsMessage = 'NextAuth authorize exploded'
+
+    global.fetch = jest
+      .fn()
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+
+        if (url.includes('nextauth-credentials-diagnostics')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ ok: false, message: nextAuthDiagnosticsMessage, name: 'AuthorizeError' }),
+          })
+        }
+
+        if (url.includes('firebase-diagnostics')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ ok: true, uid: 'uid', projectId: 'project' }),
+          })
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`)
+      }) as unknown as typeof fetch
+
+    const { default: SignInPage } = await import('../../../pages/auth/signin')
+
+    render(<SignInPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(nextAuthDiagnosticsMessage)
+    })
+  })
+
+  it('combines diagnostics when both Firebase and NextAuth accept the credentials', async () => {
+    mockSignInWithPopup.mockResolvedValue({
+      user: {
+        getIdToken: jest.fn().mockResolvedValue('id-token'),
+        refreshToken: 'refresh-token',
+      },
+    })
+
+    mockCredentialFromResult.mockReturnValue({ accessToken: 'access-token' })
+
+    mockSignIn.mockResolvedValue({
+      error: 'CredentialsSignin',
+      ok: false,
+      status: 401,
+    })
+
+    global.fetch = jest
+      .fn()
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+
+        if (url.includes('nextauth-credentials-diagnostics')) {
+          return Promise.resolve({ ok: true, json: async () => ({ ok: true }) })
+        }
+
+        if (url.includes('firebase-diagnostics')) {
+          return Promise.resolve({ ok: true, json: async () => ({ ok: true, uid: 'uid', projectId: 'project' }) })
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`)
+      }) as unknown as typeof fetch
+
+    const { default: SignInPage } = await import('../../../pages/auth/signin')
+
+    render(<SignInPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'NextAuth authorize() and Firebase Admin both accepted the credentials when retried directly, but the sign-in endpoint still responded with "CredentialsSignin". Check the server logs for callback or session errors.'
+      )
+    })
+  })
+
+  it('falls back to NextAuth error when diagnostics return nothing', async () => {
+    mockSignInWithPopup.mockResolvedValue({
+      user: {
+        getIdToken: jest.fn().mockResolvedValue('id-token'),
+        refreshToken: 'refresh-token',
+      },
+    })
+
+    mockCredentialFromResult.mockReturnValue({ accessToken: 'access-token' })
+
+    const nextAuthError = 'Server rejected credentials'
+
+    mockSignIn.mockResolvedValue({
+      error: nextAuthError,
+      ok: false,
+      status: 401,
+    })
+
+    global.fetch = jest
+      .fn()
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+
+        if (url.includes('nextauth-credentials-diagnostics')) {
+          return Promise.resolve({ ok: false })
+        }
+
+        if (url.includes('firebase-diagnostics')) {
+          return Promise.resolve({ ok: false })
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`)
+      }) as unknown as typeof fetch
+
+    const { default: SignInPage } = await import('../../../pages/auth/signin')
+
+    render(<SignInPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(nextAuthError)
+    })
+  })
+})

--- a/__tests__/pages/dashboard/new-ui/client-accounts.test.tsx
+++ b/__tests__/pages/dashboard/new-ui/client-accounts.test.tsx
@@ -1,0 +1,39 @@
+import type { GetServerSidePropsContext } from 'next'
+import { getSession } from 'next-auth/react'
+
+import { getServerSideProps } from '../../../../pages/dashboard/new-ui/client-accounts'
+
+jest.mock('next-auth/react', () => ({
+  getSession: jest.fn(),
+}))
+
+describe('Client Accounts (Refine preview) getServerSideProps', () => {
+  const mockContext = {} as GetServerSidePropsContext
+  const getSessionMock = getSession as jest.Mock
+
+  beforeEach(() => {
+    getSessionMock.mockReset()
+  })
+
+  it('redirects to sign-in when no authenticated user is present', async () => {
+    getSessionMock.mockResolvedValue(null)
+
+    const result = await getServerSideProps(mockContext)
+
+    expect(result).toEqual({
+      redirect: { destination: '/api/auth/signin', permanent: false },
+    })
+    expect(getSessionMock).toHaveBeenCalledWith(mockContext)
+  })
+
+  it('allows access when the session only includes user information', async () => {
+    getSessionMock.mockResolvedValue({
+      user: { name: 'Ada Lovelace', email: 'ada@example.com' },
+    })
+
+    const result = await getServerSideProps(mockContext)
+
+    expect(result).toEqual({ props: {} })
+    expect(getSessionMock).toHaveBeenCalledWith(mockContext)
+  })
+})

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -9,19 +9,20 @@ const firebaseConfig = {
   projectId:            process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
   storageBucket:        process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
   messagingSenderId:    process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-  appId:                process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
+  appId:                process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
 }
-
-console.log('🔥 Firebase config:', firebaseConfig)
-Object.entries(firebaseConfig).forEach(([k, v]) => {
-  console.log(`   ${k}: ${v}`)
-})
 
 const DEFAULT_DATABASE_ID = 'mel-sessions'
 const PROJECTS_DATABASE_ID = 'epl-projects'
 
-console.log('📚 Firestore database ID:', DEFAULT_DATABASE_ID)
-console.log('📚 Firestore projects database ID:', PROJECTS_DATABASE_ID)
+if (process.env.NODE_ENV !== 'production') {
+  console.log('🔥 Firebase config:', firebaseConfig)
+  Object.entries(firebaseConfig).forEach(([k, v]) => {
+    console.log(`   ${k}: ${v}`)
+  })
+  console.log('📚 Firestore database ID:', DEFAULT_DATABASE_ID)
+  console.log('📚 Firestore projects database ID:', PROJECTS_DATABASE_ID)
+}
 
 export const app = !getApps().length
   ? initializeApp(firebaseConfig)

--- a/pages/api/auth/nextauth-credentials-diagnostics.ts
+++ b/pages/api/auth/nextauth-credentials-diagnostics.ts
@@ -1,0 +1,110 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { getAuthOptions } from './[...nextauth]'
+
+interface DiagnosticsSuccessResponse {
+  ok: true
+}
+
+interface DiagnosticsFailureResponse {
+  ok: false
+  message?: string
+  name?: string
+}
+
+type DiagnosticsResponse = DiagnosticsSuccessResponse | DiagnosticsFailureResponse
+
+type AuthorizeContext = {
+  query: NextApiRequest['query']
+  body: unknown
+  headers: NextApiRequest['headers']
+  method: NextApiRequest['method']
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<DiagnosticsResponse>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    res.status(405).json({ ok: false, message: 'Method Not Allowed', name: 'MethodNotAllowed' })
+    return
+  }
+
+  const body = typeof req.body === 'object' && req.body !== null ? req.body : {}
+  const idToken = typeof (body as Record<string, unknown>).idToken === 'string'
+    ? ((body as Record<string, unknown>).idToken as string)
+    : ''
+
+  if (!idToken.trim()) {
+    res.status(400).json({ ok: false, message: 'Missing Firebase ID token', name: 'MissingTokenError' })
+    return
+  }
+
+  try {
+    const options = await getAuthOptions()
+    const credentialsProvider = options.providers.find(
+      (provider: any) => provider.id === 'credentials' && provider.type === 'credentials'
+    ) as { authorize?: (credentials: Record<string, string>, ctx: AuthorizeContext) => Promise<unknown> } | undefined
+
+    if (!credentialsProvider?.authorize) {
+      res.status(200).json({
+        ok: false,
+        message: 'NextAuth credentials provider is not configured.',
+        name: 'CredentialsProviderMissing',
+      })
+      return
+    }
+
+    const authorizeContext: AuthorizeContext = {
+      query: req.query,
+      body,
+      headers: req.headers,
+      method: req.method,
+    }
+
+    const normalizedCredentials: Record<string, string> = {
+      idToken,
+    }
+
+    const accessToken = (body as Record<string, unknown>).accessToken
+    if (typeof accessToken === 'string' && accessToken.trim()) {
+      normalizedCredentials.accessToken = accessToken
+    }
+
+    const refreshToken = (body as Record<string, unknown>).refreshToken
+    if (typeof refreshToken === 'string' && refreshToken.trim()) {
+      normalizedCredentials.refreshToken = refreshToken
+    }
+
+    try {
+      const user = await credentialsProvider.authorize(normalizedCredentials, authorizeContext)
+
+      if (!user) {
+        res.status(200).json({
+          ok: false,
+          message: 'NextAuth authorize returned null for the supplied credentials.',
+          name: 'CredentialsAuthorizeReturnedNull',
+        })
+        return
+      }
+
+      res.status(200).json({ ok: true })
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'NextAuth authorize threw an unknown error while verifying the credentials.'
+      const name = error instanceof Error && error.name ? error.name : 'UnknownAuthorizeError'
+      console.error('[auth] NextAuth credentials diagnostics failed', error)
+      res.status(200).json({ ok: false, message, name })
+    }
+  } catch (error) {
+    console.error('[auth] Unable to load NextAuth options for diagnostics', error)
+    res.status(200).json({
+      ok: false,
+      message: 'Failed to load NextAuth configuration for diagnostics.',
+      name: 'NextAuthOptionsError',
+    })
+  }
+}

--- a/pages/dashboard/new-ui/client-accounts.tsx
+++ b/pages/dashboard/new-ui/client-accounts.tsx
@@ -234,7 +234,7 @@ export default function ClientAccountsPage() {
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const session = await getSession(ctx)
-  if (!session?.accessToken) {
+  if (!session?.user) {
     return {
       redirect: {
         destination: "/api/auth/signin",


### PR DESCRIPTION
## Summary
- add a NextAuth diagnostics API route that replays the credentials authorize flow and reports failures
- combine the NextAuth and Firebase diagnostics in the sign-in page so users see the most informative message when Google sign-in fails
- expand the Google sign-in tests to cover the new diagnostics combinations and preserve the fallback behaviour

## Testing
- npx jest __tests__/pages/auth/signin.test.tsx
- npx jest __tests__/pages/dashboard/new-ui/client-accounts.test.tsx
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23145d4e88323931f3627c96a4770