### PR TITLE
Simplify production deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-vercel-prod.yml
+++ b/.github/workflows/deploy-to-vercel-prod.yml
@@ -2,7 +2,8 @@ name: Deploy to Vercel Production
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -14,7 +15,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,9 +22,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
@@ -35,14 +32,8 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-      - name: Build
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
       - name: Deploy to Production
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- restrict the production deployment workflow to only run on the main branch
- remove local dependency installation and build steps so the job only deploys with the Vercel CLI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a00fad1483239de8d6a897a94d10